### PR TITLE
fix(mux): Use `$TERM_PROGRAM` in multiplexer detection

### DIFF
--- a/lua/smart-splits/config.lua
+++ b/lua/smart-splits/config.lua
@@ -40,10 +40,11 @@ local M = setmetatable({}, {
 function M.set_default_multiplexer()
   -- unless explicitly disabled, try to determine it automatically
   if config.multiplexer_integration ~= false then
-    if vim.env.TMUX ~= nil then
+    if vim.env.TERM_PROGRAM == 'tmux' then
       config.multiplexer_integration = 'tmux'
-    elseif vim.env.WEZTERM_PANE ~= nil then
+    elseif vim.env.TERM_PROGRAM == 'WezTerm' then
       config.multiplexer_integration = 'wezterm'
+    -- Kitty doesn't use $TERM_PROGRAM
     elseif vim.env.KITTY_LISTEN_ON ~= nil then
       config.multiplexer_integration = 'kitty'
     end


### PR DESCRIPTION
`$TMUX` will return a value if it's running on your system, even if it's not in the active pane/emulator. `$TERM_PROGRAM` will be more accurate to the instance running.

To reproduce issue:

1. In any terminal emulator, run tmux
2. Run WezTerm and neovim
3. Use plugin commands. Plugin silently fails because it thinks it should be running tmux commands, not WezTerm commands.