### PR TITLE
feat(mux): Resize with multiplexer when only single window in `tmux`

### DIFF
--- a/lua/smart-splits/api.lua
+++ b/lua/smart-splits/api.lua
@@ -160,13 +160,13 @@ end
 local function resize(direction, amount)
   amount = amount or config.default_amount
 
-  -- don't try to horizontally resize a full width window
-  if (direction == 'left' or direction == 'right') and is_full_width() then
+  -- if a full width window and horizontall resize check if we can resize with multiplexer
+  if (direction == 'left' or direction == 'right') and is_full_width() and mux.resize_pane(direction, amount) then
     return
   end
 
-  -- don't try to vertically resize a full height window
-  if (direction == 'down' or direction == 'up') and is_full_height() then
+  -- if a full height window and vertical resize check if we can resize with multiplexer
+  if (direction == 'down' or direction == 'up') and is_full_height() and mux.resize_pane(direction, amount) then
     return
   end
 

--- a/lua/smart-splits/mux/init.lua
+++ b/lua/smart-splits/mux/init.lua
@@ -57,7 +57,7 @@ function M.is_enabled()
 end
 
 ---Try moving with multiplexer
----@param direction string direction to move
+---@param direction Direction direction to move
 ---@param will_wrap boolean whether to wrap around edge
 ---@return boolean whether we moved with multiplexer or not
 function M.move_pane(direction, will_wrap)
@@ -80,6 +80,28 @@ function M.move_pane(direction, will_wrap)
   end
 
   return move_multiplexer_inner(directions_reverse[direction], multiplexer)
+end
+
+---Try resizing with multiplexer
+---@param direction Direction direction to resize
+---@param amount number amount to resize
+---@return boolean whether we resized with multiplexer or not
+function M.resize_pane(direction, amount)
+  local multiplexer = M.get()
+  if not multiplexer or not multiplexer.is_in_session() then
+    return false
+  end
+  if config.disable_multiplexer_nav_when_zoomed and multiplexer.current_pane_is_zoomed() then
+    return false
+  end
+
+  local ok = multiplexer.resize_pane(direction, amount)
+  if not ok then
+    vim.notify('[smart-splits.nvim] Failed to resize multiplexer pane', vim.log.levels.ERROR)
+    return false
+  end
+
+  return true
 end
 
 return M

--- a/lua/smart-splits/mux/kitty.lua
+++ b/lua/smart-splits/mux/kitty.lua
@@ -85,4 +85,14 @@ function M.next_pane(direction)
   return ok
 end
 
+function M.resize_pane(_, _)
+  if not M.is_in_session() then
+    return false
+  end
+
+  -- not possible with Kitty, since Kitty uses wider/narrower/taller/shorter
+  -- instead of up/down/left/right
+  return false
+end
+
 return M

--- a/lua/smart-splits/mux/tmux.lua
+++ b/lua/smart-splits/mux/tmux.lua
@@ -11,7 +11,7 @@ local function get_socket_path()
     return nil
   end
 
-  return vim.split(tmux, ',')[1]
+  return vim.split(tmux, ',', { trimempty = true })[1]
 end
 
 local function tmux_exec(cmd, as_list)
@@ -157,6 +157,19 @@ function M.next_pane(direction)
   direction = dir_keys_tmux[direction] ---@diagnostic disable-line
   local ok, _ = pcall(function()
     tmux_exec(string.format('select-pane -%s', direction))
+  end)
+
+  return ok
+end
+
+function M.resize_pane(direction)
+  if not M.is_in_session() then
+    return false
+  end
+
+  direction = dir_keys_tmux[direction] ---@diagnostic disable-line
+  local ok, _ = pcall(function()
+    tmux_exec(string.format('resize-pane -%s 5', direction))
   end)
 
   return ok

--- a/lua/smart-splits/mux/tmux.lua
+++ b/lua/smart-splits/mux/tmux.lua
@@ -162,14 +162,14 @@ function M.next_pane(direction)
   return ok
 end
 
-function M.resize_pane(direction)
+function M.resize_pane(direction, amount)
   if not M.is_in_session() then
     return false
   end
 
   direction = dir_keys_tmux[direction] ---@diagnostic disable-line
   local ok, _ = pcall(function()
-    tmux_exec(string.format('resize-pane -%s 5', direction))
+    tmux_exec(string.format('resize-pane -%s %s', direction, amount))
   end)
 
   return ok

--- a/lua/smart-splits/mux/wezterm.lua
+++ b/lua/smart-splits/mux/wezterm.lua
@@ -122,4 +122,14 @@ function M.next_pane(direction)
   return ok
 end
 
+function M.resize_pane(_, _)
+  if not M.is_in_session() then
+    return false
+  end
+
+  -- TODO implement when possible
+  -- https://github.com/wez/wezterm/issues/3471
+  return false
+end
+
 return M

--- a/lua/smart-splits/types.lua
+++ b/lua/smart-splits/types.lua
@@ -6,3 +6,4 @@
 ---@field is_in_session fun():boolean
 ---@field current_pane_is_zoomed fun():boolean
 ---@field next_pane fun(direction:Direction):boolean
+---@field resize_pane fun(direction:Direction, amount:number):boolean


### PR DESCRIPTION
Hi, thanks for a great plugin :) 

There is just a small one thing that I am missing - ability to resize multiplexer windows from the neovim window when there are no splits. This PR adds support for that. 

I don't know much about kitty nor wezterm, so for now I put there some notification that this operation is not supported. 