### PR TITLE
docs: add note about wezterm integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,11 @@ bind-key -T copy-mode-vi 'C-\' select-pane -l
 > The plugin is small, and smart about not loading modules unnecessarily, so it should
 > have minimal impact on your startup time. It adds about 0.07ms on my setup.
 
+> **Note**
+> Pane resizing currently requires a nightly build of Wezterm.
+> Check the output of `wezterm cli adjust-pane-size` to see if your build supports it; if not,
+> you can check how to obtain a nightly build by following the instructions [here](https://wezfurlong.org/wezterm/installation.html).
+
 Add the following snippet to your `~/.config/wezterm/wezterm.lua`:
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -342,8 +342,8 @@ bind-key -T copy-mode-vi 'C-\' select-pane -l
 
 > **Note**
 > Pane resizing currently requires a nightly build of Wezterm.
-> Check the output of `wezterm cli adjust-pane-size` to see if your build supports it; if not,
-> you can check how to obtain a nightly build by following the instructions [here](https://wezfurlong.org/wezterm/installation.html).
+> Check the output of `wezterm cli adjust-pane-size --help` to see if your build supports it; if not,
+> you can check how to obtain a nightly build by [following the instructions here](https://wezfurlong.org/wezterm/installation.html).
 
 Add the following snippet to your `~/.config/wezterm/wezterm.lua`:
 


### PR DESCRIPTION
The `adjust-pane-size` subcommand of `wezterm cli` is currently only available in nightly versions, [as explained here](https://wezfurlong.org/wezterm/cli/cli/adjust-pane-size.html). This commit adds a note in the readme with this info. (this commit should be reverted after the subcommand is available in stable builds)