### PR TITLE
fix: E5108 error in command line buffer

### DIFF
--- a/lua/smart-splits/api.lua
+++ b/lua/smart-splits/api.lua
@@ -469,7 +469,7 @@ vim.tbl_map(function(direction)
     amount = amount or (vim.v.count1 * config.default_amount)
     pcall(resize, direction, amount)
     -- guarantee we haven't moved the cursor by accident
-    vim.api.nvim_set_current_win(cur_win_id)
+    pcall(vim.api.nvim_set_current_win, cur_win_id)
     is_resizing = false
     -- luacheck:ignore
     vim.o.eventignore = eventignore_orig


### PR DESCRIPTION
error detail:

```
E5108: Error executing lua ...are/nvim/lazy/smart-splits.nvim/lua/smart-splits/api.lua:472: E11: Invalid in command-line window; <CR> executes, CTRL-C quits
stack traceback:
        [C]: in function 'nvim_set_current_win'
        ...are/nvim/lazy/smart-splits.nvim/lua/smart-splits/api.lua:472: in function 'resize_up'
        [string ":lua"]:1: in main chunk
```

Steps to repro:

1. `q:` to open cmd win.
2. try to resize the cmd win.