### PR TITLE
feat(mux): Improved tmux integration performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,13 +305,18 @@ You will need to set up keymaps in your `tmux`, `wezterm`, or `kitty` configs to
 Add the following snippet to your `~/.tmux.conf`/`~/.config/tmux/tmux.conf` file (customizing the keys and resize amount if desired):
 
 ```tmux
-# Smart pane switching with awareness of Vim splits.
+# '@pane-is-vim' is a pane-local option that is set by the plugin on load,
+# and unset when Neovim exits or suspends; note that this means you'll probably
+# not want to lazy-load smart-splits.nvim, as the variable won't be set until
+# the plugin is loaded
 
+# Smart pane switching with awareness of Neovim splits.
 bind-key -n C-h if -F "#{@pane-is-vim}" 'send-keys C-h'  'select-pane -L'
 bind-key -n C-j if -F "#{@pane-is-vim}" 'send-keys C-j'  'select-pane -D'
 bind-key -n C-k if -F "#{@pane-is-vim}" 'send-keys C-k'  'select-pane -U'
 bind-key -n C-l if -F "#{@pane-is-vim}" 'send-keys C-l'  'select-pane -R'
 
+# Smart pane resizing with awareness of Neovim splits.
 bind-key -n M-h if -F "#{@pane-is-vim}" 'send-keys M-h' 'resize-pane -L 3'
 bind-key -n M-j if -F "#{@pane-is-vim}" 'send-keys M-j' 'resize-pane -D 3'
 bind-key -n M-k if -F "#{@pane-is-vim}" 'send-keys M-k' 'resize-pane -U 3'

--- a/README.md
+++ b/README.md
@@ -306,24 +306,22 @@ Add the following snippet to your `~/.tmux.conf`/`~/.config/tmux/tmux.conf` file
 
 ```tmux
 # Smart pane switching with awareness of Vim splits.
-# See: https://github.com/christoomey/vim-tmux-navigator
-is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-    | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-bind-key -n C-h if-shell "$is_vim" 'send-keys C-h'  'select-pane -L'
-bind-key -n C-j if-shell "$is_vim" 'send-keys C-j'  'select-pane -D'
-bind-key -n C-k if-shell "$is_vim" 'send-keys C-k'  'select-pane -U'
-bind-key -n C-l if-shell "$is_vim" 'send-keys C-l'  'select-pane -R'
+"
+bind-key -n C-h if -F "#{@pane-is-vim}" 'send-keys C-h'  'select-pane -L'
+bind-key -n C-j if -F "#{@pane-is-vim}" 'send-keys C-j'  'select-pane -D'
+bind-key -n C-k if -F "#{@pane-is-vim}" 'send-keys C-k'  'select-pane -U'
+bind-key -n C-l if -F "#{@pane-is-vim}" 'send-keys C-l'  'select-pane -R'
 
-bind-key -n M-h if-shell "$is_vim" 'send-keys M-h' 'resize-pane -L 3'
-bind-key -n M-j if-shell "$is_vim" 'send-keys M-j' 'resize-pane -D 3'
-bind-key -n M-k if-shell "$is_vim" 'send-keys M-k' 'resize-pane -U 3'
-bind-key -n M-l if-shell "$is_vim" 'send-keys M-l' 'resize-pane -R 3'
+bind-key -n M-h if -F "#{@pane-is-vim}" 'send-keys M-h' 'resize-pane -L 3'
+bind-key -n M-j if -F "#{@pane-is-vim}" 'send-keys M-j' 'resize-pane -D 3'
+bind-key -n M-k if -F "#{@pane-is-vim}" 'send-keys M-k' 'resize-pane -U 3'
+bind-key -n M-l if -F "#{@pane-is-vim}" 'send-keys M-l' 'resize-pane -R 3'
 
 tmux_version='$(tmux -V | sed -En "s/^tmux ([0-9]+(.[0-9]+)?).*/\1/p")'
 if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
-    "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
+    "bind-key -n 'C-\\' if -F \"#{@pane-is-vim}\" 'send-keys C-\\'  'select-pane -l'"
 if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
-    "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
+    "bind-key -n 'C-\\' if -F \"#{@pane-is-vim}\" 'send-keys C-\\\\'  'select-pane -l'"
 
 bind-key -T copy-mode-vi 'C-h' select-pane -L
 bind-key -T copy-mode-vi 'C-j' select-pane -D
@@ -365,7 +363,7 @@ smart_splits.apply_to_config(config, {
   modifiers = {
     move = 'CTRL', -- modifier to use for pane movement, e.g. CTRL+h to move left
     resize = 'META', -- modifier to use for pane resize, e.g. META+h to resize to the left
-  }
+  },
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Add the following snippet to your `~/.tmux.conf`/`~/.config/tmux/tmux.conf` file
 
 ```tmux
 # Smart pane switching with awareness of Vim splits.
-"
+
 bind-key -n C-h if -F "#{@pane-is-vim}" 'send-keys C-h'  'select-pane -L'
 bind-key -n C-j if -F "#{@pane-is-vim}" 'send-keys C-j'  'select-pane -D'
 bind-key -n C-k if -F "#{@pane-is-vim}" 'send-keys C-k'  'select-pane -U'

--- a/autoload/smart_splits.vim
+++ b/autoload/smart_splits.vim
@@ -48,7 +48,7 @@ function s:encode_b64(str, size)
   return chunked
 endfunction
 
-function s:write(var)
+function smart_splits#write_wezterm_var(var)
   if filewritable('/dev/fd/2') == 1
     let l:success = writefile([a:var], '/dev/fd/2', 'b') == 0
   else
@@ -57,18 +57,6 @@ function s:write(var)
   return l:success
 endfunction
 
-function s:format_var(val)
+function smart_splits#format_wezterm_var(val)
   return printf("\033]1337;SetUserVar=IS_NVIM=%s\007", s:encode_b64(a:val, 0))
 endfunction
-
-let s:are_we_wezterm = luaeval("require('smart-splits.mux.utils').are_we_wezterm()")
-
-if s:are_we_wezterm
-  call s:write(s:format_var("true"))
-  " Set to false if nvim is suspended with ctrl+z
-  autocmd VimSuspend * :call s:write(s:format_var("false"))
-  " Set to true if nvim is resumed after being suspended with ctrl+z
-  autocmd VimResume * :call s:write(s:format_var("true"))
-  " Set to false when nvim exits
-  autocmd VimLeave * :call s:write(s:format_var("false"))
-endif

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1708118438,
+        "narHash": "sha256-kk9/0nuVgA220FcqH/D2xaN6uGyHp/zoxPNUmPCMmEE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5863c27340ba4de8f83e7e3c023b9599c3cb3c80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+# this flake installs tmux and sets up a basic tmux config for testing the plugin integration
+{
+  inputs = {
+    nixpkgs = { url = "github:nixos/nixpkgs/nixos-unstable"; };
+    flake-utils = { url = "github:numtide/flake-utils"; };
+  };
+  outputs = { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        tmux_conf = pkgs.writeText "tmux.conf" ''
+          # Smart pane switching with awareness of Vim splits.
+
+          bind-key -n C-h if -F "#{@pane-is-vim}" 'send-keys C-h'  'select-pane -L'
+          bind-key -n C-j if -F "#{@pane-is-vim}" 'send-keys C-j'  'select-pane -D'
+          bind-key -n C-k if -F "#{@pane-is-vim}" 'send-keys C-k'  'select-pane -U'
+          bind-key -n C-l if -F "#{@pane-is-vim}" 'send-keys C-l'  'select-pane -R'
+
+          bind-key -n M-h if -F "#{@pane-is-vim}" 'send-keys M-h' 'resize-pane -L 3'
+          bind-key -n M-j if -F "#{@pane-is-vim}" 'send-keys M-j' 'resize-pane -D 3'
+          bind-key -n M-k if -F "#{@pane-is-vim}" 'send-keys M-k' 'resize-pane -U 3'
+          bind-key -n M-l if -F "#{@pane-is-vim}" 'send-keys M-l' 'resize-pane -R 3'
+
+          tmux_version='$(tmux -V | sed -En "s/^tmux ([0-9]+(.[0-9]+)?).*/\1/p")'
+          if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
+              "bind-key -n 'C-\\' if -F \"#{@pane-is-vim}\" 'send-keys C-\\'  'select-pane -l'"
+          if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
+              "bind-key -n 'C-\\' if -F \"#{@pane-is-vim}\" 'send-keys C-\\\\'  'select-pane -l'"
+
+          bind-key -T copy-mode-vi 'C-h' select-pane -L
+          bind-key -T copy-mode-vi 'C-j' select-pane -D
+          bind-key -T copy-mode-vi 'C-k' select-pane -U
+          bind-key -T copy-mode-vi 'C-l' select-pane -R
+          bind-key -T copy-mode-vi 'C-\' select-pane -l
+
+          # split panes using | and -
+          bind | split-window -h -l 75 -c '#{pane_current_path}'
+          bind - split-window -v -l 25 -c '#{pane_current_path}'
+
+          # Make undercurls work properly in Neovim
+          # Undercurl support
+          set -as terminal-overrides ',*:Smulx=\E[4::%p1%dm'
+          # Underscore colours - needs tmux-3.0
+          set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'
+        '';
+      in {
+        devShell = pkgs.mkShell {
+          name = "shell with tmux";
+
+          packages = with pkgs; [ tmux ];
+
+          shellHook = ''
+            tmux -f ${tmux_conf}
+          '';
+        };
+      });
+}

--- a/lua/smart-splits/config.lua
+++ b/lua/smart-splits/config.lua
@@ -3,7 +3,6 @@ local log = lazy.require_on_exported_call('smart-splits.log') --[[@as SmartSplit
 local types = require('smart-splits.types')
 local AtEdgeBehavior = types.AtEdgeBehavior
 local Multiplexer = types.Multiplexer
-local utils = require('smart-splits.utils')
 local mux_utils = require('smart-splits.mux.utils')
 
 ---@class SmartResizeModeHooks
@@ -108,7 +107,18 @@ function M.set_default_multiplexer()
 end
 
 function M.setup(new_config)
+  local original_mux = config.multiplexer_integration
+
   config = vim.tbl_deep_extend('force', config, new_config or {})
+  -- if the mux setting changed, run startup again
+  if
+    original_mux ~= nil
+    and original_mux ~= false
+    and #tostring(original_mux or '') == 0
+    and original_mux ~= config.multiplexer_integration
+  then
+    mux_utils.startup()
+  end
 
   -- check deprecated settings
   ---@diagnostic disable:undefined-field

--- a/lua/smart-splits/config.lua
+++ b/lua/smart-splits/config.lua
@@ -4,6 +4,7 @@ local types = require('smart-splits.types')
 local AtEdgeBehavior = types.AtEdgeBehavior
 local Multiplexer = types.Multiplexer
 local utils = require('smart-splits.utils')
+local mux_utils = require('smart-splits.mux.utils')
 
 ---@class SmartResizeModeHooks
 ---@field on_enter fun()|nil
@@ -82,7 +83,7 @@ function M.set_default_multiplexer()
 
   -- if running in a GUI instead of terminal TUI, disable mux
   -- because you aren't in any terminal, you're in a Neovim GUI
-  if utils.are_we_gui() then
+  if mux_utils.are_we_gui() then
     config.multiplexer_integration = false
     return nil
   end

--- a/lua/smart-splits/mux/init.lua
+++ b/lua/smart-splits/mux/init.lua
@@ -52,6 +52,9 @@ function M.get()
   end
 
   local ok, mux = pcall(require, string.format('smart-splits.mux.%s', config.multiplexer_integration))
+  if not ok then
+    log.error(mux)
+  end
   return ok and mux or nil
 end
 

--- a/lua/smart-splits/mux/tmux.lua
+++ b/lua/smart-splits/mux/tmux.lua
@@ -1,6 +1,6 @@
 local types = require('smart-splits.types')
 local Direction = types.Direction
-local Log = require('smart-splts.log')
+local log = require('smart-splits.log')
 
 local dir_keys_tmux = {
   [Direction.left] = 'L',
@@ -150,24 +150,24 @@ end
 function M.on_init()
   local pane_id = M.current_pane_id()
   if not pane_id then
-    Log.warn('tmux init: could not detect pane ID!')
+    log.warn('tmux init: could not detect pane ID!')
     return
   end
   tmux_exec({ 'set-option', '-pt', pane_id, '@pane-is-vim', 1 })
   if vim.v.shell_error ~= 0 then
-    Log.warn('tmux init: failed to detect pane_id')
+    log.warn('tmux init: failed to detect pane_id')
   end
 end
 
 function M.on_exit()
   local pane_id = M.current_pane_id()
   if not pane_id then
-    Log.warn('tmux init: could not detect pane ID!')
+    log.warn('tmux init: could not detect pane ID!')
     return
   end
   tmux_exec({ 'set-option', '-pt', pane_id, '@pane-is-vim', 0 })
   if vim.v.shell_error ~= 0 then
-    Log.warn('tmux init: failed to detect pane_id')
+    log.warn('tmux init: failed to detect pane_id')
   end
 end
 

--- a/lua/smart-splits/mux/utils.lua
+++ b/lua/smart-splits/mux/utils.lua
@@ -1,0 +1,34 @@
+local M = {}
+
+---Check if Neovim is running in Wezterm TUI
+---@return boolean
+function M.are_we_wezterm()
+  if M.are_we_gui() then
+    return false
+  end
+  local term = vim.trim((vim.env.TERM_PROGRAM or ''):lower())
+  local wezterm_pane = vim.trim(vim.env.WEZTERM_PANE or '')
+  return term == 'wezterm' or wezterm_pane ~= ''
+end
+
+function M.are_we_tmux()
+  if M.are_we_gui() then
+    return false
+  end
+
+  local term = vim.trim((vim.env.TERM_PROGRAM or ''):lower())
+  return term == 'tmux'
+end
+
+---Check if Neovim is running in a GUI (rather than TUI)
+---@return boolean
+function M.are_we_gui()
+  -- if running in a GUI instead of terminal TUI, disable mux
+  -- because you aren't in any terminal, you're in a Neovim GUI
+  local current_ui = vim.tbl_filter(function(ui)
+    return ui.chan == 1
+  end, vim.api.nvim_list_uis())[1]
+  return current_ui ~= nil and not current_ui.stdin_tty and not current_ui.stdout_tty
+end
+
+return M

--- a/lua/smart-splits/mux/wezterm.lua
+++ b/lua/smart-splits/mux/wezterm.lua
@@ -150,4 +150,16 @@ function M.split_pane(direction, size)
   return ok
 end
 
+function M.on_init()
+  local format_var = vim.fn['smart_splits#format_wezterm_var']
+  local write_var = vim.fn['smart_splits#write_wezterm_var']
+  write_var(format_var('true'))
+end
+
+function M.on_exit()
+  local format_var = vim.fn['smart_splits#format_wezterm_var']
+  local write_var = vim.fn['smart_splits#write_wezterm_var']
+  write_var(format_var('false'))
+end
+
 return M

--- a/lua/smart-splits/types.lua
+++ b/lua/smart-splits/types.lua
@@ -7,6 +7,8 @@
 ---@field resize_pane fun(direction:SmartSplitsDirection, amount:number):boolean
 ---@field split_pane fun(direction:SmartSplitsDirection,size:number|nil):boolean
 ---@field type SmartSplitsMultiplexerType
+---@field on_init fun()|nil
+---@field on_exit fun()|nil
 
 ---@alias SmartSplitsDirection 'left'|'right'|'up'|'down'
 

--- a/lua/smart-splits/utils.lua
+++ b/lua/smart-splits/utils.lua
@@ -19,26 +19,4 @@ function M.is_floating_window(win_id)
   return win_cfg and (win_cfg.relative ~= '' or not win_cfg.relative)
 end
 
----Check if Neovim is running in Wezterm TUI
----@return boolean
-function M.are_we_wezterm()
-  if M.are_we_gui() then
-    return false
-  end
-  local term = vim.trim((vim.env.TERM_PROGRAM or ''):lower())
-  local wezterm_pane = vim.trim(vim.env.WEZTERM_PANE or '')
-  return term == 'wezterm' or wezterm_pane ~= ''
-end
-
----Check if Neovim is running in a GUI (rather than TUI)
----@return boolean
-function M.are_we_gui()
-  -- if running in a GUI instead of terminal TUI, disable mux
-  -- because you aren't in any terminal, you're in a Neovim GUI
-  local current_ui = vim.tbl_filter(function(ui)
-    return ui.chan == 1
-  end, vim.api.nvim_list_uis())[1]
-  return current_ui ~= nil and not current_ui.stdin_tty and not current_ui.stdout_tty
-end
-
 return M

--- a/plugin/smart-splits.lua
+++ b/plugin/smart-splits.lua
@@ -5,3 +5,4 @@ vim.tbl_map(function(cmd)
 end, cmds)
 
 require('smart-splits.config').set_default_multiplexer()
+require('smart-splits.mux.utils').startup()

--- a/plugin/smart-splits.vim
+++ b/plugin/smart-splits.vim
@@ -61,7 +61,7 @@ function s:format_var(val)
   return printf("\033]1337;SetUserVar=IS_NVIM=%s\007", s:encode_b64(a:val, 0))
 endfunction
 
-let s:are_we_wezterm = luaeval("require('smart-splits.utils').are_we_wezterm()")
+let s:are_we_wezterm = luaeval("require('smart-splits.mux.utils').are_we_wezterm()")
 
 if s:are_we_wezterm
   call s:write(s:format_var("true"))


### PR DESCRIPTION
This PR also adds a hook system for multiplexer integrations to run initialization and cleanup functions. `mux.on_init()` is called on startup and `VimResume` while `mux.on_exit()` is called on `VimSuspend` and `VimLeave`.

@b0o would you mind giving this a test for me? It has been a long time since I've used tmux and I don't have a configuration for it at the moment.

# To Test:

1. Use the modified tmux configuration in the README.md changes of this PR
2. Use tmux
3. Ensure `smart-splits.nvim` either auto-detects or is set to use tmux
4. Create multiple tmux splits
5. Open Neovim in one of them and ensure `smart-splits.nvim` is loaded


For me:

- [x] Make sure I didn't break it for Wezterm :stuck_out_tongue: 