### PR TITLE
fix(mux): nvim-wezterm panes not seamlessly switching while using wsl2

### DIFF
--- a/lua/smart-splits/config.lua
+++ b/lua/smart-splits/config.lua
@@ -26,7 +26,7 @@ local mux_utils = require('smart-splits.mux.utils')
 ---@field ignored_events string[]
 ---@field multiplexer_integration SmartSplitsMultiplexerType|false
 ---@field disable_multiplexer_nav_when_zoomed boolean
----@field wezterm_bin_path string|nil
+---@field wezterm_cli_path string|nil
 ---@field kitty_password string|nil
 ---@field setup fun(cfg:table)
 ---@field set_default_multiplexer fun():string|nil
@@ -34,6 +34,7 @@ local mux_utils = require('smart-splits.mux.utils')
 
 ---@type SmartSplitsConfig
 local config = { ---@diagnostic disable-line:missing-fields
+  wezterm_cli_path = 'wezterm',
   ignored_buftypes = {
     'nofile',
     'quickfix',
@@ -112,7 +113,6 @@ function M.setup(new_config)
 
   config = vim.tbl_deep_extend('force', config, new_config or {})
   -- if the mux setting changed, run startup again
-
   if
     original_mux ~= nil
     and original_mux ~= false
@@ -148,9 +148,6 @@ function M.setup(new_config)
   if config.wrap_at_edge == false or config.wrap_at_edge == true then
     config.at_edge = config.wrap_at_edge == true and AtEdgeBehavior.wrap or AtEdgeBehavior.stop
     vim.deprecate('config.wrap_at_edge', "config.at_edge = 'wrap'|'split'|'stop'", 'smart-splits.nvim')
-  end
-  if config.wezterm_bin_path then
-    M.wezterm_bin_path = config.wezterm_bin_path
   end
   ---@diagnostic enable:undefined-field
 end

--- a/lua/smart-splits/config.lua
+++ b/lua/smart-splits/config.lua
@@ -26,6 +26,7 @@ local mux_utils = require('smart-splits.mux.utils')
 ---@field ignored_events string[]
 ---@field multiplexer_integration SmartSplitsMultiplexerType|false
 ---@field disable_multiplexer_nav_when_zoomed boolean
+---@field wezterm_bin_path string|nil
 ---@field kitty_password string|nil
 ---@field setup fun(cfg:table)
 ---@field set_default_multiplexer fun():string|nil
@@ -111,6 +112,7 @@ function M.setup(new_config)
 
   config = vim.tbl_deep_extend('force', config, new_config or {})
   -- if the mux setting changed, run startup again
+
   if
     original_mux ~= nil
     and original_mux ~= false
@@ -146,6 +148,9 @@ function M.setup(new_config)
   if config.wrap_at_edge == false or config.wrap_at_edge == true then
     config.at_edge = config.wrap_at_edge == true and AtEdgeBehavior.wrap or AtEdgeBehavior.stop
     vim.deprecate('config.wrap_at_edge', "config.at_edge = 'wrap'|'split'|'stop'", 'smart-splits.nvim')
+  end
+  if config.wezterm_bin_path then
+    M.wezterm_bin_path = config.wezterm_bin_path
   end
   ---@diagnostic enable:undefined-field
 end

--- a/lua/smart-splits/config.lua
+++ b/lua/smart-splits/config.lua
@@ -111,6 +111,11 @@ end
 function M.setup(new_config)
   local original_mux = config.multiplexer_integration
 
+  if mux_utils.is_WSL() then
+    -- on WSL default to .exe unless explicitly set in user config
+    new_config.wezterm_cli_path = new_config.wezterm_cli_path or 'wezterm.exe'
+  end
+
   config = vim.tbl_deep_extend('force', config, new_config or {})
   -- if the mux setting changed, run startup again
   if

--- a/lua/smart-splits/mux/utils.lua
+++ b/lua/smart-splits/mux/utils.lua
@@ -18,6 +18,8 @@ function M.are_we_wezterm()
   return term == 'wezterm'
 end
 
+--- Check if we're in WSL
+---@return boolean
 function M.is_WSL()
   return vim.env.WSL_DISTRO_NAME ~= nil and vim.env.WSL_DISTRO_NAME ~= ''
 end

--- a/lua/smart-splits/mux/utils.lua
+++ b/lua/smart-splits/mux/utils.lua
@@ -9,6 +9,19 @@ function M.are_we_tmux()
   return term == 'tmux'
 end
 
+function M.are_we_wezterm()
+  if M.are_we_gui() then
+    return false
+  end
+
+  local term = vim.trim((vim.env.TERM_PROGRAM or ''):lower())
+  return term == 'wezterm'
+end
+
+function M.is_WSL()
+  return vim.env.WSL_DISTRO_NAME ~= nil and vim.env.WSL_DISTRO_NAME ~= ''
+end
+
 ---Check if Neovim is running in a GUI (rather than TUI)
 ---@return boolean
 function M.are_we_gui()

--- a/lua/smart-splits/mux/wezterm.lua
+++ b/lua/smart-splits/mux/wezterm.lua
@@ -1,4 +1,5 @@
 local Direction = require('smart-splits.types').Direction
+local isWSL = require('smart-splits.utils').isWSL
 
 local dir_keys_wezterm = {
   [Direction.left] = 'Left',
@@ -16,7 +17,11 @@ local dir_keys_wezterm_splits = {
 
 local function wezterm_exec(cmd)
   local command = vim.deepcopy(cmd)
-  table.insert(command, 1, 'wezterm')
+  if isWSL then
+    table.insert(command, 1, 'wezterm.exe')
+  else
+    table.insert(command, 1, 'wezterm')
+  end
   table.insert(command, 2, 'cli')
   return vim.fn.system(command)
 end

--- a/lua/smart-splits/mux/wezterm.lua
+++ b/lua/smart-splits/mux/wezterm.lua
@@ -1,5 +1,6 @@
 local Direction = require('smart-splits.types').Direction
-local isWSL = require('smart-splits.utils').isWSL
+local utils = require('smart-splits.utils')
+local config = require('smart-splits.config')
 
 local dir_keys_wezterm = {
   [Direction.left] = 'Left',
@@ -17,8 +18,9 @@ local dir_keys_wezterm_splits = {
 
 local function wezterm_exec(cmd)
   local command = vim.deepcopy(cmd)
-  if isWSL then
-    table.insert(command, 1, 'wezterm.exe')
+  local wezterm_bin_path = config.wezterm_bin_path or 'wezterm.exe'
+  if utils.isWSL() then
+    table.insert(command, 1, wezterm_bin_path)
   else
     table.insert(command, 1, 'wezterm')
   end

--- a/lua/smart-splits/mux/wezterm.lua
+++ b/lua/smart-splits/mux/wezterm.lua
@@ -1,5 +1,4 @@
 local Direction = require('smart-splits.types').Direction
-local utils = require('smart-splits.utils')
 local config = require('smart-splits.config')
 
 local dir_keys_wezterm = {
@@ -18,12 +17,7 @@ local dir_keys_wezterm_splits = {
 
 local function wezterm_exec(cmd)
   local command = vim.deepcopy(cmd)
-  local wezterm_bin_path = config.wezterm_bin_path or 'wezterm.exe'
-  if utils.isWSL() then
-    table.insert(command, 1, wezterm_bin_path)
-  else
-    table.insert(command, 1, 'wezterm')
-  end
+  table.insert(command, 1, config.wezterm_cli_path)
   table.insert(command, 2, 'cli')
   return vim.fn.system(command)
 end

--- a/lua/smart-splits/utils.lua
+++ b/lua/smart-splits/utils.lua
@@ -1,9 +1,5 @@
 local M = {}
 
-function M.isWSL()
-  return vim.env.WSL_DISTRO_NAME ~= nil and vim.env.WSL_DISTRO_NAME ~= ''
-end
-
 function M.tbl_find(tbl, predicate)
   for idx, value in ipairs(tbl) do
     if predicate(value) then

--- a/lua/smart-splits/utils.lua
+++ b/lua/smart-splits/utils.lua
@@ -1,5 +1,11 @@
 local M = {}
 
+local function checkIfWSL()
+  return io.popen('grep -i WSL /proc/version')
+end
+
+M.isWSL = checkIfWSL()
+
 function M.tbl_find(tbl, predicate)
   for idx, value in ipairs(tbl) do
     if predicate(value) then

--- a/lua/smart-splits/utils.lua
+++ b/lua/smart-splits/utils.lua
@@ -1,10 +1,8 @@
 local M = {}
 
-local function checkIfWSL()
-  return io.popen('grep -i WSL /proc/version')
+function M.isWSL()
+  return vim.env.WSL_DISTRO_NAME ~= nil and vim.env.WSL_DISTRO_NAME ~= ''
 end
-
-M.isWSL = checkIfWSL()
 
 function M.tbl_find(tbl, predicate)
   for idx, value in ipairs(tbl) do


### PR DESCRIPTION
# Issue
When using wsl in wezterm ( installed on windows ), the cursor does switch from wezterm to nvim, however it doesn't switch from nvim to wezterm.

# Cause
As mentioned, the plugin is using wezterm cli for switching panes, however the command 'wezterm' is not recognized in WSL environment therefore the switching doesn't work.

# Solution
Check if the environment is WSL and use the command 'wezterm.exe' instead of 'wezterm' ( note: this works only if the wezterm path on windows is set correctly on WSLENV ).