### PR TITLE
fix: Detect and handle nested Vim instances in Tmux

### DIFF
--- a/lua/smart-splits/mux/tmux.lua
+++ b/lua/smart-splits/mux/tmux.lua
@@ -2,6 +2,8 @@ local types = require('smart-splits.types')
 local Direction = types.Direction
 local log = require('smart-splits.log')
 
+local is_nested_vim = false
+
 local dir_keys_tmux = {
   [Direction.left] = 'L',
   [Direction.right] = 'R',
@@ -152,6 +154,10 @@ function M.on_init()
     log.warn('tmux init: could not detect pane ID!')
     return
   end
+  if tonumber(tmux_exec({ 'show-options', '-pqvt', pane_id, '@pane-is-vim' })) == 1 then
+    is_nested_vim = true
+    return
+  end
   tmux_exec({ 'set-option', '-pt', pane_id, '@pane-is-vim', 1 })
   if vim.v.shell_error ~= 0 then
     log.warn('tmux init: failed to detect pane_id')
@@ -159,6 +165,9 @@ function M.on_init()
 end
 
 function M.on_exit()
+  if is_nested_vim then
+    return
+  end
   local pane_id = M.current_pane_id()
   if not pane_id then
     log.warn('tmux init: could not detect pane ID!')


### PR DESCRIPTION
### Bug Description

Split navigation stops working after opening/exiting Neovim from within a Neovim terminal window when using the Tmux integrations.

### Minimal Config

#### Neovim

```lua
local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
if not vim.loop.fs_stat(lazypath) then
  -- stylua: ignore
  vim.fn.system({ "git", "clone", "--filter=blob:none", "https://github.com/folke/lazy.nvim.git", "--branch=stable", lazypath })
end
vim.opt.rtp:prepend(lazypath)

require("lazy").setup({
  {
    "mrjones2014/smart-splits.nvim",
    event = "VeryLazy",
    config = function()
      local map = function(mode, lhs, rhs, opts)
        local base = { noremap = true, silent = true }
        vim.keymap.set(mode, lhs, rhs, vim.tbl_extend("force", base, opts or {}))
      end

      local ss = require("smart-splits")

      ss.setup()

      map({ "n", "i", "t" }, "<M-h>", ss.move_cursor_left)
      map({ "n", "i", "t" }, "<M-j>", ss.move_cursor_down)
      map({ "n", "i", "t" }, "<M-k>", ss.move_cursor_up)
      map({ "n", "i", "t" }, "<M-l>", ss.move_cursor_right)
    end,
  },
})
```

#### Tmux

```tmux
set -g prefix C-a

bind -n 'M-h' if -F "#{@pane-is-vim}" 'send M-h' 'selectp -L'
bind -n 'M-j' if -F "#{@pane-is-vim}" 'send M-j' 'selectp -D'
bind -n 'M-k' if -F "#{@pane-is-vim}" 'send M-k' 'selectp -U'
bind -n 'M-l' if -F "#{@pane-is-vim}" 'send M-l' 'selectp -R'
bind -n 'M-;' if -F "#{@pane-is-vim}" 'send M-;' 'lastp'

bind -T copy-mode-vi 'M-h' selectp -L
bind -T copy-mode-vi 'M-j' selectp -D
bind -T copy-mode-vi 'M-k' selectp -U
bind -T copy-mode-vi 'M-l' selectp -R
bind -T copy-mode-vi 'M-;' lastp

bind '\' splitw -v -c '#{pane_current_path}'
bind '|' splitw -h -c '#{pane_current_path}'
unbind '"'
unbind '%'
```

### Steps To Reproduce

1. Open Tmux.
2. Open Neovim.
3. Open a Neovim terminal window.
4. Open Neovim from within the Neovim terminal window.
5. Exit the nested Neovim editor.
6. Exit the terminal window.
7. Attempt to navigate between Neovim splits.

### Fix Description

This PR fixes the issue by checking if the `@pane-is-vim` Tmux option is already set to `1` on initialization. If it is, then we set a flag to prevent unsetting the option on exit.