### PR TITLE
fix: never wrap unless at_edge is set to wrap

### DIFF
--- a/lua/smart-splits/mux/init.lua
+++ b/lua/smart-splits/mux/init.lua
@@ -89,7 +89,11 @@ function M.move_pane(direction, will_wrap, at_edge)
     return multiplexer_moved
   end
 
-  return move_multiplexer_inner(directions_reverse[direction], multiplexer)
+  if at_edge == AtEdgeBehavior.wrap then
+    return move_multiplexer_inner(directions_reverse[direction], multiplexer)
+  end
+
+  return false
 end
 
 ---Try resizing with multiplexer


### PR DESCRIPTION
fixes #170 

---

In the future, there might room for further refactoring by collapsing the two consecutive `if` statements.

```diff
-  if multiplexer_moved or not will_wrap then
+  if multiplexer_moved or at_edge ~= AtEdgeBehavior.wrap then
     return multiplexer_moved
   end
```

This would also mean that `will_wrap` no longer needs to be passed to this function in the first place.