### PR TITLE
fix(api): move_cursor_previous is a no-op if previous win no longer exists

### DIFF
--- a/lua/smart-splits/api.lua
+++ b/lua/smart-splits/api.lua
@@ -492,7 +492,7 @@ end, {
 
 function M.move_cursor_previous()
   local win = mux_utils.get_previous_win()
-  if win then
+  if win and vim.api.nvim_win_is_valid(win) then
     vim.api.nvim_set_current_win(win)
   end
 end


### PR DESCRIPTION
Fixes #172 