### PR TITLE
fix: ensure that direction_keys can be configured

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -65,6 +65,7 @@ local function apply_to_config(config_builder, plugin_config)
     _smart_splits_wezterm_config.direction_keys = plugin_config.direction_keys
       or _smart_splits_wezterm_config.direction_keys
     -- update the direction_keys mappings to reflect configured ones
+    direction_keys = {} -- reset the direction_keys table to overwrite defaults
     for i, v in ipairs(directions) do
       local key = plugin_config.direction_keys[i]
       direction_keys[key] = v

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -26,12 +26,8 @@ local _smart_splits_wezterm_config = {
   },
 }
 
-local direction_keys = {
-  h = 'Left',
-  j = 'Down',
-  k = 'Up',
-  l = 'Right',
-}
+local directions = { 'Left', 'Down', 'Up', 'Right' }
+local direction_keys = {}
 
 local function split_nav(resize_or_move, key)
   local modifier = resize_or_move == 'resize' and _smart_splits_wezterm_config.modifiers.resize
@@ -68,6 +64,11 @@ local function apply_to_config(config_builder, plugin_config)
   if plugin_config then
     _smart_splits_wezterm_config.direction_keys = plugin_config.direction_keys
       or _smart_splits_wezterm_config.direction_keys
+    -- update the direction_keys mappings to reflect configured ones
+    for i, v in ipairs(directions) do
+      local key = plugin_config.direction_keys[i]
+      direction_keys[key] = v
+    end
     if plugin_config.modifiers then
       _smart_splits_wezterm_config.modifiers.move = plugin_config.modifiers.move
         or _smart_splits_wezterm_config.modifiers.move

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -27,7 +27,12 @@ local _smart_splits_wezterm_config = {
 }
 
 local directions = { 'Left', 'Down', 'Up', 'Right' }
-local direction_keys = {}
+local direction_keys = {
+  h = 'Left',
+  j = 'Down',
+  k = 'Up',
+  l = 'Right',
+}
 
 local function split_nav(resize_or_move, key)
   local modifier = resize_or_move == 'resize' and _smart_splits_wezterm_config.modifiers.resize


### PR DESCRIPTION
Currently configuring the wezterm plugin with custom `direction_keys` will not work due to the hardcoded key-to-direction table. This PR fixes this issue by constructing the `direction_keys` table based on the configured keys instead.