### PR TITLE
fix(mux): Unable to use its own operations in neovim

### DIFF
--- a/kitty/neighboring_window.py
+++ b/kitty/neighboring_window.py
@@ -1,9 +1,38 @@
+from kitty.key_encoding import KeyEvent, parse_shortcut
+from kittens.tui.handler import result_handler
+
+
 def main():
     pass
 
 
+def encode_key_mapping(window, key_mapping):
+    mods, key = parse_shortcut(key_mapping)
+    event = KeyEvent(
+        mods=mods,
+        key=key,
+        shift=bool(mods & 1),
+        alt=bool(mods & 2),
+        ctrl=bool(mods & 4),
+        super=bool(mods & 8),
+        hyper=bool(mods & 16),
+        meta=bool(mods & 32),
+    ).as_window_system_event()
+
+    return window.encoded_key(event)
+
+
+@result_handler(no_ui=True)
 def handle_result(args, result, target_window_id, boss):
-    boss.active_tab.neighboring_window(args[1])
+    window = boss.window_id_map.get(target_window_id)
 
+    keymap = args[2]
 
-handle_result.no_ui = True
+    cmd = window.child.foreground_cmdline[0]
+    if cmd == 'nvim':
+        encoded = encode_key_mapping(window, keymap)
+        window.write_to_child(encoded)
+    elif cmd == 'tmux':
+        pass
+    else:
+        boss.active_tab.neighboring_window(args[1])

--- a/kitty/relative_resize.py
+++ b/kitty/relative_resize.py
@@ -1,15 +1,36 @@
 # Based on MIT licensed code at https://github.com/chancez/dotfiles/blob/badc69d3895a6a942285amount26b8c372a55d77533eamount/kitty/.config/kitty/relative_resize.py
 from kittens.tui.handler import result_handler
+from kitty.key_encoding import KeyEvent, parse_shortcut
+
+
+def encode_key_mapping(window, key_mapping):
+    mods, key = parse_shortcut(key_mapping)
+    event = KeyEvent(
+        mods=mods,
+        key=key,
+        shift=bool(mods & 1),
+        alt=bool(mods & 2),
+        ctrl=bool(mods & 4),
+        super=bool(mods & 8),
+        hyper=bool(mods & 16),
+        meta=bool(mods & 32),
+    ).as_window_system_event()
+
+    return window.encoded_key(event)
+
 
 def main(args):
     pass
+
 
 def relative_resize_window(direction, amount, target_window_id, boss):
     window = boss.window_id_map.get(target_window_id)
     if window is None:
         return
 
-    neighbors = boss.active_tab.current_layout.neighbors_for_window(window, boss.active_tab.windows)
+    neighbors = boss.active_tab.current_layout.neighbors_for_window(
+        window, boss.active_tab.windows
+    )
     current_window_id = boss.active_tab.active_window
 
     left_neighbors = neighbors.get('left')
@@ -57,8 +78,20 @@ def relative_resize_window(direction, amount, target_window_id, boss):
     elif direction == 'down' and bottom_neighbors:
         boss.active_tab.resize_window('taller', amount)
 
+
 @result_handler(no_ui=True)
 def handle_result(args, result, target_window_id, boss):
     direction = args[1]
     amount = int(args[2])
-    relative_resize_window(direction, amount, target_window_id, boss)
+    window = boss.window_id_map.get(target_window_id)
+
+    keymap = args[3]
+
+    cmd = window.child.foreground_cmdline[0]
+    if cmd == 'nvim':
+        encoded = encode_key_mapping(window, keymap)
+        window.write_to_child(encoded)
+    elif cmd == 'tmux':
+        pass
+    else:
+        relative_resize_window(direction, amount, target_window_id, boss)


### PR DESCRIPTION
cause:
Due to the fact that after deleting pass_key.py, it didn't deal with the fact that kitty didn't send shortcuts to neovim when the environment was in neovim, resulting in not being able to do its own window operations inside neovim