### PR TITLE
feat(mux): Use tmux inside kitty and compatible with window shortcuts

### DIFF
--- a/kitty/neighboring_window.py
+++ b/kitty/neighboring_window.py
@@ -29,10 +29,9 @@ def handle_result(args, result, target_window_id, boss):
     keymap = args[2]
 
     cmd = window.child.foreground_cmdline[0]
-    if cmd == 'nvim':
+    if cmd == 'tmux':
+        keymap = args[2]
         encoded = encode_key_mapping(window, keymap)
         window.write_to_child(encoded)
-    elif cmd == 'tmux':
-        pass
     else:
         boss.active_tab.neighboring_window(args[1])

--- a/kitty/relative_resize.py
+++ b/kitty/relative_resize.py
@@ -85,13 +85,10 @@ def handle_result(args, result, target_window_id, boss):
     amount = int(args[2])
     window = boss.window_id_map.get(target_window_id)
 
-    keymap = args[3]
-
     cmd = window.child.foreground_cmdline[0]
-    if cmd == 'nvim':
+    if cmd == 'tmux':
+        keymap = args[3]
         encoded = encode_key_mapping(window, keymap)
         window.write_to_child(encoded)
-    elif cmd == 'tmux':
-        pass
     else:
         relative_resize_window(direction, amount, target_window_id, boss)

--- a/kitty/split_window.py
+++ b/kitty/split_window.py
@@ -23,4 +23,10 @@ def handle_result(args, result, target_window_id, boss):
         return
 
     direction = args[1]
-    split_window(boss, direction)
+    cmd = window.child.foreground_cmdline[0]
+    if cmd == 'tmux':
+        keymap = args[2]
+        encoded = encode_key_mapping(window, keymap)
+        window.write_to_child(encoded)
+    else:
+        split_window(boss, direction)


### PR DESCRIPTION


kitty.conf
**The shortcut here is passed to tmux**
```conf
map cmd+j kitten neighboring_window.py bottom cmd+j
map cmd+k kitten neighboring_window.py top    cmd+k
map cmd+h kitten neighboring_window.py left   cmd+h
map cmd+l kitten neighboring_window.py right  cmd+l

map --when-focus-on var:IS_NVIM cmd+j
map --when-focus-on var:IS_NVIM cmd+k
map --when-focus-on var:IS_NVIM cmd+h
map --when-focus-on var:IS_NVIM cmd+l

map ctrl+shift+j kitten relative_resize.py down  3 ctrl+shift+j 
map ctrl+shift+k kitten relative_resize.py up    3 ctrl+shift+k
map ctrl+shift+h kitten relative_resize.py left  3 ctrl+shift+h
map ctrl+shift+l kitten relative_resize.py right 3 ctrl+shift+l

map --when-focus-on var:IS_NVIM ctrl+shift+j
map --when-focus-on var:IS_NVIM ctrl+shift+k
map --when-focus-on var:IS_NVIM ctrl+shift+h
map --when-focus-on var:IS_NVIM ctrl+shift+l

map cmd+ctrl+j kitten split_window.py down    cmd+ctrl+j
map cmd+ctrl+k kitten split_window.py up      cmd+ctrl+k
map cmd+ctrl+h kitten split_window.py left    cmd+ctrl+h
map cmd+ctrl+l kitten split_window.py right   cmd+ctrl+l
```

tmux.conf
```conf
bind-key -n M-h if -F "#{@pane-is-vim}" 'send-keys M-h'  'select-pane -L'
bind-key -n M-j if -F "#{@pane-is-vim}" 'send-keys M-j'  'select-pane -D'
bind-key -n M-k if -F "#{@pane-is-vim}" 'send-keys M-k'  'select-pane -U'
bind-key -n M-l if -F "#{@pane-is-vim}" 'send-keys M-l'  'select-pane -R'

bind-key -n C-S-h if -F "#{@pane-is-vim}" 'send-keys C-S-h' 'resize-pane -L 3'
bind-key -n C-S-j if -F "#{@pane-is-vim}" 'send-keys C-S-j' 'resize-pane -D 3'
bind-key -n C-S-k if -F "#{@pane-is-vim}" 'send-keys C-S-k' 'resize-pane -U 3'
bind-key -n C-S-l if -F "#{@pane-is-vim}" 'send-keys C-S-l' 'resize-pane -R 3'

bind-key -n C-M-k if -F "#{@pane-is-vim}" 'send-keys C-M-k' 'split-window -v -c "#{pane_current_path}"'
bind-key -n C-M-j if -F "#{@pane-is-vim}" 'send-keys C-M-j' 'split-window -v -c "#{pane_current_path}"'
bind-key -n C-M-l if -F "#{@pane-is-vim}" 'send-keys C-M-l' 'split-window -h -c "#{pane_current_path}"'
bind-key -n C-M-h if -F "#{@pane-is-vim}" 'send-keys C-M-h' 'split-window -h -c "#{pane_current_path}"'
```

neovim
**On mac systems, the cmd key cannot be used with ‘D’ but rather ‘M’, because tmux sends over the M** 
```lua
vim.keymap.set("n", "<C-S-k>", function()
    smart_splits.resize_up()
end)
vim.keymap.set("n", "<C-S-j>", function()
    smart_splits.resize_down()
end)
vim.keymap.set("n", "<C-S-h>", function()
    smart_splits.resize_left()
end)
vim.keymap.set("n", "<C-S-l>", function()
    smart_splits.resize_right()
end)

vim.keymap.set("n",  "<M-k>", function()
    smart_splits.move_cursor_up()
end)
vim.keymap.set("n", "<M-j>", function()
    smart_splits.move_cursor_down()
end)
vim.keymap.set("n", "<M-h>", function()
    smart_splits.move_cursor_left()
end)
vim.keymap.set("n","<M-l>", function()
    smart_splits.move_cursor_right()
end)

local mux = require("smart-splits.mux").get()
vim.keymap.set("n","<M-C-k>", function()
    mux.split_pane("up")
end)
vim.keymap.set("n", "<M-C-j>", function()
    mux.split_pane("down")
end)
vim.keymap.set("n", "<M-C-h>", function()
    mux.split_pane("left")
end)
vim.keymap.set("n", "<M-C-l>", function()
    mux.split_pane("right")
end)
```
![kitty_tmux_move](https://github.com/mrjones2014/smart-splits.nvim/assets/30570532/acd0fc4a-4539-448e-a501-54c9529b8c6b)
![kitty_tmux_resize](https://github.com/mrjones2014/smart-splits.nvim/assets/30570532/1a620df2-ce68-401a-884a-9e62098a3bbb)
