### PR TITLE
fix: [!NOTE] Block

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ such as [nvim-tree.lua](https://github.com/kyazdani42/nvim-tree.lua)
 which tries to maintain its own width unless manually resized. Note that
 nothing is ignored when moving between splits, only when resizing.
 
-> [!NOTE] > `smart-splits.nvim` does not map any keys on it's own. See [Usage](#usage).
+> [!NOTE]
+> `smart-splits.nvim` does not map any keys on it's own. See [Usage](#usage).
 
 Defaults are shown below:
 


### PR DESCRIPTION
The title says it, Fixed not renderable [!NOTE] block in README.md due to missing LF.