### PR TITLE
feat(mux): wezterm supports log_level config

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,8 @@ smart_splits.apply_to_config(config, {
     move = 'CTRL', -- modifier to use for pane movement, e.g. CTRL+h to move left
     resize = 'META', -- modifier to use for pane resize, e.g. META+h to resize to the left
   },
+  -- log level to use: info, warn, error
+  log_level = 'info'
 })
 ```
 


### PR DESCRIPTION
Thanks for the great plugin 😄 

as per title this adds a `log_level` option for wezterm users with a default of `info` (as it currently is).

This allows turning off the logs in wezterm when calling `apply_to_config`, e.g:

```lua
smart_splits.apply_to_config(config, {
	log_level = "warn",
})
```