### PR TITLE
fix(mux): Default WSL wezterm path at require time

### DIFF
--- a/lua/smart-splits/config.lua
+++ b/lua/smart-splits/config.lua
@@ -36,7 +36,7 @@ local mux_utils = require('smart-splits.mux.utils')
 
 ---@type SmartSplitsConfig
 local config = { ---@diagnostic disable-line:missing-fields
-  wezterm_cli_path = 'wezterm',
+  wezterm_cli_path = mux_utils.is_WSL() and 'wezterm.exe' or 'wezterm',
   ignored_buftypes = {
     'nofile',
     'quickfix',
@@ -113,11 +113,6 @@ end
 
 function M.setup(new_config)
   local original_mux = config.multiplexer_integration
-
-  if mux_utils.is_WSL() then
-    -- on WSL default to .exe unless explicitly set in user config
-    new_config.wezterm_cli_path = new_config.wezterm_cli_path or 'wezterm.exe'
-  end
 
   config = vim.tbl_deep_extend('force', config, new_config or {})
   -- if the mux setting changed, run startup again


### PR DESCRIPTION
Should improve WSL support for users in lazy environments; if you don't call `.setup()` it should still work with this change.