### PR TITLE
fix: Fix `on_exit` when nvim is running in a Flatpak package

### DIFF
--- a/lua/smart-splits/mux/tmux.lua
+++ b/lua/smart-splits/mux/tmux.lua
@@ -182,7 +182,9 @@ function M.on_exit()
     return
   end
   local args = { 'set-option', '-pt', pane_id, '@pane-is-vim', 0 }
-  local cmd = vim.list_extend({ 'tmux', '-S', socket }, args, 1, #args)
+  local cmd = os.getenv('FLATPAK_ID')
+      and vim.list_extend({ 'flatpak-spawn', '--host', 'tmux', '-S', socket }, args, 1, #args)
+    or vim.list_extend({ 'tmux', '-S', socket }, args, 1, #args)
 
   vim.fn.jobstart(cmd, { detach = true })
 end


### PR DESCRIPTION
````
Error detected while processing VimSuspend Autocommands for "*":
Error executing lua callback: Vim:E475: Invalid value for argument cmd: 'tmux' is not executable
stack traceback:
        [C]: in function 'jobstart'
        ...vim/lazy/smart-splits.nvim/lua/smart-splits/mux/tmux.lua:187: in function 'on_exit'
        ...im/lazy/smart-splits.nvim/lua/smart-splits/mux/utils.lua:74: in function <...im/lazy/smart-splits.nvim/lua/smart-splits/mux/utils.lua:73>
````