### PR TITLE
fix(docs): kitty support for split_pane operation

### DIFF
--- a/lua/smart-splits/mux/init.lua
+++ b/lua/smart-splits/mux/init.lua
@@ -118,7 +118,7 @@ function M.resize_pane(direction, amount)
   return ok
 end
 
----Try creating a new mux split pane. Not supported in Kitty multiplexer.
+---Try creating a new mux split pane.
 ---@param direction SmartSplitsDirection
 ---@param size number|nil
 ---@return boolean success


### PR DESCRIPTION
I am able to call `smart-splits::mux::split_pane` when using kitty as a backend so I think that sentence in the doc string on main is no longer the case. https://github.com/michaelfortunato/smart-splits.nvim/blob/793cd0c14cce113710939f2ede7a8cbf69bbadef/lua/smart-splits/mux/kitty.lua#L111
Thanks