### PR TITLE
feat(mux): add basic tpm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ You can also set the desired multiplexer integration in lazy environments before
 You can use the package manager [TPM](https://github.com/tmux-plugins/tpm) to configure your Tmux setup:
 
 > [!NOTE]
-> Currently, jumping to the last viewed pane is not supported.
+> Currently, jumping to the last viewed pane is not supported. Feel free to submit a PR for it!
 
 ```tmux
 set -g @plugin 'mrjones2014/smart-splits.nvim'

--- a/README.md
+++ b/README.md
@@ -314,7 +314,30 @@ You can also set the desired multiplexer integration in lazy environments before
 
 #### Tmux
 
-Add the following snippet to your `~/.tmux.conf`/`~/.config/tmux/tmux.conf` file (customizing the keys and resize amount if desired):
+You can use the package manager [TPM](https://github.com/tmux-plugins/tpm) to configure your Tmux setup:
+
+> [!NOTE]
+> Currently, jumping to the last viewed pane is not supported.
+
+```tmux
+set -g @plugin 'mrjones2014/smart-splits.nvim'
+
+# Optional configurations with their default values if omitted:
+
+set -g @smart-splits_no_wrap '' # to disable wrapping. (any value disables wrapping)
+
+set -g @smart-splits_move_left_key  'C-h' # key-mapping for navigation.
+set -g @smart-splits_move_down_key  'C-j' #  --"--
+set -g @smart-splits_move_up_key    'C-k' #  --"--
+set -g @smart-splits_move_right_key 'C-l' #  --"--
+
+set -g @smart-splits_resize_left_key  'M-h' # key-mapping for resizing.
+set -g @smart-splits_resize_down_key  'M-j' #  --"--
+set -g @smart-splits_resize_up_key    'M-k' #  --"--
+set -g @smart-splits_resize_right_key 'M-l' #  --"--
+```
+
+Alternatively, add the following snippet to your `~/.tmux.conf`/`~/.config/tmux/tmux.conf` file (customizing the keys and resize amount if desired):
 
 ```tmux
 # '@pane-is-vim' is a pane-local option that is set by the plugin on load,

--- a/smart-splits.tmux
+++ b/smart-splits.tmux
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# -------------------------------------------- #
+# Config file for `smart-splits.nvim` for TPM. #
+# -------------------------------------------- #
+
+get_option() {
+    local value=$(tmux show-options -gvq "$1")
+    echo "${value:-$2}"
+}
+
+no_wrap=$(get_option '@smart-splits_no_wrap' '')
+
+move_left_key=$(get_option  '@smart-splits_move_left_key'  'C-h')
+move_down_key=$(get_option  '@smart-splits_move_down_key'  'C-j')
+move_up_key=$(get_option    '@smart-splits_move_up_key'    'C-k')
+move_right_key=$(get_option '@smart-splits_move_right_key' 'C-l')
+
+resize_left_key=$(get_option  '@smart-splits_resize_left_key'  'M-h')
+resize_down_key=$(get_option  '@smart-splits_resize_down_key'  'M-j')
+resize_up_key=$(get_option    '@smart-splits_resize_up_key'    'M-k')
+resize_right_key=$(get_option '@smart-splits_resize_right_key' 'M-l')
+
+# Setup all the navigation key-mappings.
+setup_navigation() {
+    if [ -z $no_wrap ]; then
+        tmux bind-key -n "$move_left_key"  if -F '#{@pane-is-vim}' "send-keys $move_left_key"  'select-pane -L'
+        tmux bind-key -n "$move_down_key"  if -F '#{@pane-is-vim}' "send-keys $move_down_key"  'select-pane -D'
+        tmux bind-key -n "$move_up_key"    if -F '#{@pane-is-vim}' "send-keys $move_up_key"    'select-pane -U'
+        tmux bind-key -n "$move_right_key" if -F '#{@pane-is-vim}' "send-keys $move_right_key" 'select-pane -R'
+        tmux bind-key -T copy-mode-vi "$move_left_key"  select-pane -L
+        tmux bind-key -T copy-mode-vi "$move_down_key"  select-pane -D
+        tmux bind-key -T copy-mode-vi "$move_up_key"    select-pane -U
+        tmux bind-key -T copy-mode-vi "$move_right_key" select-pane -R
+    else
+        tmux bind-key -n "$move_left_key"  if -F '#{@pane-is-vim}' "send-keys $move_left_key"  "if -F '#{pane_at_left}'   '' 'select-pane -L'"
+        tmux bind-key -n "$move_down_key"  if -F '#{@pane-is-vim}' "send-keys $move_down_key"  "if -F '#{pane_at_bottom}' '' 'select-pane -D'"
+        tmux bind-key -n "$move_up_key"    if -F '#{@pane-is-vim}' "send-keys $move_up_key"    "if -F '#{pane_at_top}'    '' 'select-pane -U'"
+        tmux bind-key -n "$move_right_key" if -F '#{@pane-is-vim}' "send-keys $move_right_key" "if -F '#{pane_at_right}'  '' 'select-pane -R'"
+        tmux bind-key -T copy-mode-vi "$move_left_key"  if -F '#{pane_at_left}'   '' 'select-pane -L'
+        tmux bind-key -T copy-mode-vi "$move_down_key"  if -F '#{pane_at_bottom}' '' 'select-pane -D'
+        tmux bind-key -T copy-mode-vi "$move_up_key"    if -F '#{pane_at_top}'    '' 'select-pane -U'
+        tmux bind-key -T copy-mode-vi "$move_right_key" if -F '#{pane_at_right}'  '' 'select-pane -R'
+    fi
+}
+
+# Setup all the key-mappings for resizing.
+setup_resize() {
+    tmux bind-key -n "$resize_left_key"  if -F '#{@pane-is-vim}' "send-keys $resize_left_key"  'resize-pane -L 3'
+    tmux bind-key -n "$resize_down_key"  if -F '#{@pane-is-vim}' "send-keys $resize_down_key"  'resize-pane -D 3'
+    tmux bind-key -n "$resize_up_key"    if -F '#{@pane-is-vim}' "send-keys $resize_up_key"    'resize-pane -U 3'
+    tmux bind-key -n "$resize_right_key" if -F '#{@pane-is-vim}' "send-keys $resize_right_key" 'resize-pane -R 3'
+}
+
+main() {
+    setup_navigation
+    setup_resize
+}
+
+main


### PR DESCRIPTION
This adds basic support for the Tmux package manager [TPM](https://github.com/tmux-plugins/tpm).

As an aside, I didn't implement support for jumping back to previously visited panes. I'm not really well versed in sh scripting like this, thats why I didn't feel comfortable handling configurable key-mappings properly with the Tmux versions.

Also, be aware that TPM executes all `*.tmux` files at the top level automatically. Just in case future releases should any such files to the repository.

See #247