### PR TITLE
fix(mux): Restore cursor after zellij edge detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,10 @@ window:
 Add the following keymap config to your Zellij KDL config, adjusting the keys you wish to use as necessary.
 No configuration should be needed on the Neovim side.
 
+> [!NOTE]
+> This is an example. It is highly recommended to manually install the plugins and use `MessagePlugin "file:/path/to/plugin.wasm"`
+> instead of the GitHub URL!
+
 ```kdl
 keybinds {
   shared_except "locked" {

--- a/lua/smart-splits/mux/zellij.lua
+++ b/lua/smart-splits/mux/zellij.lua
@@ -36,6 +36,9 @@ function M.current_pane_at_edge()
     return false
   end
 
+  -- move back to original pane
+  zellij_exec({ 'action', 'move-focus', Direction.right })
+
   return pane_id == new_pane_id
 end
 


### PR DESCRIPTION
Related to #111 