### PR TITLE
fix(mux): Let wezterm pass keys if the active tab has only one pane

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -79,7 +79,8 @@ local function split_nav(resize_or_move, key, direction)
     key = key,
     mods = modifier,
     action = wezterm.action_callback(function(win, pane)
-      if is_vim(pane) then
+      local num_panes = #win:window:active_tab():panes()
+      if is_vim(pane) or num_panes == 1 then
         -- pass the keys through to vim/nvim
         win:perform_action({
           SendKey = {

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -79,7 +79,7 @@ local function split_nav(resize_or_move, key, direction)
     key = key,
     mods = modifier,
     action = wezterm.action_callback(function(win, pane)
-      local num_panes = #win:window:active_tab():panes()
+      local num_panes = #win:active_tab():panes()
       if is_vim(pane) or num_panes == 1 then
         -- pass the keys through to vim/nvim
         win:perform_action({


### PR DESCRIPTION
This is a typical situation if one is using tmux inside weterm. It could be possible to detect tmux by using `Pane:get_foreground_process_name()`, but it wouldn't work when using tmux in remote ssh connection (which is the main reason of this modification, since it's uncommon to run tmux inside wezterm locally)