### PR TITLE
feat(mux): support wezterm mapping

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -79,13 +79,8 @@ local Directions = { 'Left', 'Down', 'Up', 'Right' }
 local function split_nav(resize_or_move, key, direction)
   local modifier = resize_or_move == 'resize' and _smart_splits_wezterm_config.modifiers.resize
     or _smart_splits_wezterm_config.modifiers.move
-  local wezterm_modifier = modifier
-  local neovim_modifier = modifier
-  if type(modifier) == 'table' then
-    wezterm_modifier = modifier.wezterm
-    neovim_modifier = modifier.neovim
-  end
-  wezterm.log_error('oops', wezterm_modifier, neovim_modifier)
+  local wezterm_modifier = type(modifier) == 'table' and modifier.wezterm or modifier
+  local neovim_modifier = type(modifier) == 'table' and modifier.neovim or modifier
   return {
     key = key,
     mods = wezterm_modifier,

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -157,8 +157,6 @@ local function apply_to_config(config_builder, plugin_config)
     table.insert(keymaps, split_nav('resize', key, Directions[idx]))
   end
 
-  wezterm.log_info(keymaps)
-
   if config_builder.keys == nil then
     config_builder.keys = keymaps
   else


### PR DESCRIPTION
This was my approach for resolving #358.

An optional way of specifying modifiers is now:

```lua
smart_splits.apply_to_config(config, {
    modifiers = {
        -- NOTE:  This is the old way
        -- move = "SUPER",
        -- This "breaks" in neovim since `<C-l>` and `<C-L>` are
        -- indistinguishable
        -- resize = "CTRL|SHIFT",
        move = {
            wezterm = "SUPER",
            neovim = "ALT",
        },
        resize = {
            wezterm = "CTRL|SHIFT",
            neovim = "CTRL|ALT",
        },
    },
})
```

This will insert the `move.wezterm` and `resize.wezterm` key mappings into
`config.keymaps`.  When passing the keys through to `neovim` via
`action.SendKey`, it will override the `mods` with whatever is provided under
`move.neovim` and `resize.neovim`.

It checks if these values are `table`s and so should not be a breaking change.

This lets me remove all my custom config for wezterm to do basically all of
this.

I wasn't totally sure how to update the description of the
`SmartSplitsWeztermModifiers` type annotation.  Happy to also do that if you
have any thoughts.
