### PR TITLE
fix: Revert "fix: add special handling for Snacks.explorer window"

### DIFF
--- a/lua/smart-splits/utils.lua
+++ b/lua/smart-splits/utils.lua
@@ -10,30 +10,13 @@ function M.tbl_find(tbl, predicate)
   return nil
 end
 
----Check for some special cases like Snacks.explorer(),
----see https://github.com/mrjones2014/smart-splits.nvim/issues/342
-local function is_special_floating_window_treat_as_non_floating(win_id, win_config)
-  win_id = win_id or 0
-  local buf = vim.api.nvim_win_get_buf(win_id)
-  local ft = vim.bo[buf].filetype
-  -- the snacks explorer is just a snacks picker in disguise;
-  -- it is technically a floating window, but on the same z index
-  -- as the main window, so we want to treat it as a normal window
-  if ft == 'snacks_picker_list' and win_config.zindex == 33 then
-    return true
-  end
-end
-
 ---Check if a window is a floating window
 ---@param win_id number|nil window ID to check, defaults to current window (0)
 ---@return boolean
 function M.is_floating_window(win_id)
   win_id = win_id or 0
   local win_cfg = vim.api.nvim_win_get_config(win_id)
-  if is_special_floating_window_treat_as_non_floating(win_id, win_cfg) then
-    return false
-  end
-  return win_cfg.relative ~= ''
+  return win_cfg and (win_cfg.relative ~= '' or not win_cfg.relative)
 end
 
 return M


### PR DESCRIPTION
This reverts commit c4afaf23141651845e6e1966d936d79ff8939e4d.

After this reverted commit I started experienceing the following issue when resizing Snacks Explorer

<img width="966" height="1255" alt="Screenshot 2025-10-09 at 3 54 01 PM" src="https://github.com/user-attachments/assets/4a02de5e-1696-4a18-ada7-8ceefa450935" />

The special case treating Snacks explorer as non-floating broke resize
operations. Snacks explorer is a floating window (relative: "win") and
should be detected as such to allow proper resize handling.

This PR is just to spark discussion, is it reproducible to you?

Thanks for the awesome plugin!