### PR TITLE
fix: E5560: nvim_echo must not be called in a fast event context

### DIFF
--- a/lua/smart-splits/log/init.lua
+++ b/lua/smart-splits/log/init.lua
@@ -28,7 +28,9 @@ local function log_with_hl(msg, hl)
   if type(msg) ~= 'string' then
     msg = vim.inspect(msg)
   end
-  vim.api.nvim_echo({ { prefix, prefix_hl }, { msg, hl or 'None' } }, true, {})
+  vim.schedule(function()
+    vim.api.nvim_echo({ { prefix, prefix_hl }, { msg, hl or 'None' } }, true, {})
+  end)
 end
 
 local function should_log(level)


### PR DESCRIPTION
Starting up Neovim with lazy.nvim resulted in error `E5560: nvim_echo must not be called in a fast event context`.

Scheduling `nvim_echo` resolves that error.

