### PR TITLE
feat: cursor behaves fine within tmux panes and lazyvim panes #342

### DIFF
--- a/lua/smart-splits/api.lua
+++ b/lua/smart-splits/api.lua
@@ -381,6 +381,21 @@ local function move_cursor(direction, opts)
   local offset = vim.fn.winline() + vim.api.nvim_win_get_position(0)[1]
   local dir_key = DirectionKeys[direction]
 
+  if utils.is_embedded_floating_window() then
+    if utils.is_floating_window_at_screen_edge(nil, direction) then
+      if mux.move_pane(direction, true, at_edge) then
+        return
+      end
+      return
+    end
+    vim.cmd('wincmd ' .. dir_key)
+    if (direction == Direction.left or direction == Direction.right) and same_row then
+      offset = offset - vim.api.nvim_win_get_position(0)[1]
+      vim.cmd('normal! ' .. offset .. 'H')
+    end
+    return
+  end
+
   -- are we at an edge and attempting to move in the direction of the edge we're already at?
   local win_to_move_to = vim.fn.winnr(vim.v.count1 .. dir_key)
   local win_before = vim.v.count1 == 1 and vim.fn.winnr() or vim.fn.winnr(vim.v.count1 - 1 .. dir_key)

--- a/lua/smart-splits/api.lua
+++ b/lua/smart-splits/api.lua
@@ -375,7 +375,6 @@ local function move_cursor(direction, opts)
     end
     return
   end
-
   if handle_floating_window(function()
     mux.move_pane(direction, true, at_edge)
   end) then

--- a/lua/smart-splits/api.lua
+++ b/lua/smart-splits/api.lua
@@ -197,32 +197,20 @@ local function compute_direction_horizontal(direction)
 end
 
 ---@param mux_callback fun()|nil
----@param allow_embedded_nav boolean|nil when true, embedded floating windows (low zindex) are treated as normal splits
 ---@return boolean
-local function handle_floating_window(mux_callback, allow_embedded_nav)
+local function handle_floating_window(mux_callback)
   if not utils.is_floating_window() then
     return false
   end
 
-  -- Embedded floating windows (sidebars/panels with low zindex, e.g.
-  -- snacks explorer) should allow normal wincmd navigation but not resizing.
-  -- See https://github.com/mrjones2014/smart-splits.nvim/issues/342
-  if allow_embedded_nav and utils.is_embedded_floating_window() then
-    return false
-  end
-
   if config.float_win_behavior == FloatWinBehavior.previous then
-    -- focus the last accessed window.
-    -- if it's also floating, do not attempt to perform the action.
     local prev_win = vim.fn.win_getid(vim.fn.winnr('#'))
     if utils.is_floating_window(prev_win) then
       return true
     end
-
     vim.api.nvim_set_current_win(prev_win)
     return false
   elseif config.float_win_behavior == FloatWinBehavior.mux then
-    -- always forward the action to the multiplexer
     if mux_callback then
       mux_callback()
     end
@@ -372,20 +360,12 @@ local function move_cursor(direction, opts)
     end
   end
 
-  if handle_floating_window(function()
-    mux.move_pane(direction, true, at_edge)
-  end, true) then
-    return
-  end
-
-  local offset = vim.fn.winline() + vim.api.nvim_win_get_position(0)[1]
   local dir_key = DirectionKeys[direction]
+  local offset = vim.fn.winline() + vim.api.nvim_win_get_position(0)[1]
 
   if utils.is_embedded_floating_window() then
     if utils.is_floating_window_at_screen_edge(nil, direction) then
-      if mux.move_pane(direction, true, at_edge) then
-        return
-      end
+      mux.move_pane(direction, true, at_edge)
       return
     end
     vim.cmd('wincmd ' .. dir_key)
@@ -393,6 +373,12 @@ local function move_cursor(direction, opts)
       offset = offset - vim.api.nvim_win_get_position(0)[1]
       vim.cmd('normal! ' .. offset .. 'H')
     end
+    return
+  end
+
+  if handle_floating_window(function()
+    mux.move_pane(direction, true, at_edge)
+  end) then
     return
   end
 

--- a/lua/smart-splits/utils.lua
+++ b/lua/smart-splits/utils.lua
@@ -16,7 +16,22 @@ end
 function M.is_floating_window(win_id)
   win_id = win_id or 0
   local win_cfg = vim.api.nvim_win_get_config(win_id)
-  return win_cfg and (win_cfg.relative ~= '' or not win_cfg.relative)
+  return win_cfg and win_cfg.relative ~= ''
+end
+
+---Check if a window is an "embedded" floating window — one that is
+---technically floating (relative ~= '') but visually behaves like a
+---sidebar or panel (e.g. snacks explorer at zindex 33).
+---Neovim's default floating zindex is 50; anything explicitly set
+---below that signals the window is meant to coexist with normal splits.
+---@param win_id number|nil window ID to check, defaults to current window (0)
+---@return boolean
+function M.is_embedded_floating_window(win_id)
+  if not M.is_floating_window(win_id) then
+    return false
+  end
+  local win_cfg = vim.api.nvim_win_get_config(win_id or 0)
+  return win_cfg.zindex ~= nil and win_cfg.zindex < 50
 end
 
 local executables_cache = {}

--- a/lua/smart-splits/utils.lua
+++ b/lua/smart-splits/utils.lua
@@ -34,6 +34,29 @@ function M.is_embedded_floating_window(win_id)
   return win_cfg.zindex ~= nil and win_cfg.zindex < 50
 end
 
+---@param win_id number|nil window ID, defaults to current window
+---@param direction 'left'|'right'|'up'|'down'
+---@return boolean
+function M.is_floating_window_at_screen_edge(win_id, direction)
+  win_id = win_id or vim.api.nvim_get_current_win()
+  if not M.is_floating_window(win_id) then
+    return false
+  end
+  local cfg = vim.api.nvim_win_get_config(win_id)
+  local col = type(cfg.col) == 'number' and cfg.col or 0
+  local row = type(cfg.row) == 'number' and cfg.row or 0
+  if direction == 'left' then
+    return col <= 0
+  elseif direction == 'right' then
+    return col + cfg.width >= vim.o.columns
+  elseif direction == 'up' then
+    return row <= 0
+  elseif direction == 'down' then
+    return row + cfg.height >= vim.o.lines - vim.o.cmdheight
+  end
+  return false
+end
+
 local executables_cache = {}
 
 ---Run a system command.


### PR DESCRIPTION
This works fine when both resizing panes and navgating between panes.

- Fixes #342 — Allow move_cursor from embedded floating windows (e.g., snacks explorer).
- Problem: Floating windows with zindex < 50 (like snacks explorer at zindex: 33) behave visually as sidebars but were blocked by smart-splits' float detection.
- Solution: Use zindex < 50 as a heuristic — plugins deliberately set this to signal "I'm a sidebar, not an overlay". For move_cursor, treat these as normal splits; for resize, continue blocking (resizing a float makes no sense).
- Why zindex works: Neovim's default float zindex is 50. Anything explicitly lower signals intent to coexist with normal splits rather than overlay them.
```bash
move_cursor(direction)
├─ is_embedded_floating_window? (zindex < 50)
│   ├─ at screen edge? → mux handoff (tmux/wezterm)
│   └─ not at edge    → normal wincmd
└─ regular float? → apply float_win_behavior as before
resize_pane(direction)
└─ is_floating_window? (any zindex)
    └─ blocked — resizing floats is not meaningful
```

https://github.com/user-attachments/assets/19caf7b6-660d-49aa-b9ef-10e3e67d24e1

