### PR TITLE
feat: add Ghostty multiplexer backend

### DIFF
--- a/lua/smart-splits/config.lua
+++ b/lua/smart-splits/config.lua
@@ -41,7 +41,7 @@ local config = { ---@diagnostic disable-line:missing-fields
     'NvimTree',
   },
   default_amount = 3,
-  at_edge = mux_utils.are_we_kitty() and AtEdgeBehavior.stop or AtEdgeBehavior.wrap,
+  at_edge = (mux_utils.are_we_kitty() or mux_utils.are_we_ghostty()) and AtEdgeBehavior.stop or AtEdgeBehavior.wrap,
   float_win_behavior = FloatWinBehavior.previous,
   move_cursor_same_row = false,
   cursor_follows_swapped_bufs = false,
@@ -104,6 +104,8 @@ function M.set_default_multiplexer()
     config.multiplexer_integration = Multiplexer.wezterm
   elseif mux_utils.are_we_kitty() then
     config.multiplexer_integration = Multiplexer.kitty
+  elseif mux_utils.are_we_ghostty() then
+    config.multiplexer_integration = Multiplexer.ghostty
   end
 
   if type(config.multiplexer_integration) == 'string' then
@@ -130,6 +132,17 @@ function M.setup(new_config)
   -- check for incompatible settings
   if mux_utils.are_we_kitty() and config.multiplexer_integration == Multiplexer.kitty and config.at_edge == 'wrap' then
     local msg = 'Kitty multiplexer integration does not support wrapping at edge, setting to "stop"'
+    log.warn(msg)
+    vim.notify_once(msg, vim.log.levels.WARN, { title = 'smart-splits.nvim' })
+    config.at_edge = AtEdgeBehavior.stop
+  end
+
+  if
+    mux_utils.are_we_ghostty()
+    and config.multiplexer_integration == Multiplexer.ghostty
+    and config.at_edge == 'wrap'
+  then
+    local msg = 'Ghostty multiplexer integration does not support wrapping at edge, setting to "stop"'
     log.warn(msg)
     vim.notify_once(msg, vim.log.levels.WARN, { title = 'smart-splits.nvim' })
     config.at_edge = AtEdgeBehavior.stop

--- a/lua/smart-splits/mux/ghostty.lua
+++ b/lua/smart-splits/mux/ghostty.lua
@@ -1,0 +1,121 @@
+local lazy = require('smart-splits.lazy')
+local log = lazy.require_on_exported_call('smart-splits.log') --[[@as SmartSplitsLogger]]
+local utils = lazy.require_on_exported_call('smart-splits.utils')
+
+--- Execute an AppleScript snippet synchronously and return trimmed stdout.
+--- Returns empty string on failure.
+---@param script string
+---@return string
+local function osascript_str(script)
+  local out, _ = utils.system({ 'osascript', '-e', script })
+  return vim.trim(out or '')
+end
+
+--- Build an AppleScript snippet that performs a Ghostty action on the focused terminal.
+---@param action string Ghostty action string e.g. "goto_split:left"
+---@return string
+local function action_script(action)
+  return string.format(
+    'tell application "Ghostty"\n'
+      .. '  set t to focused terminal of selected tab of front window\n'
+      .. '  return perform action "%s" on t\n'
+      .. 'end tell',
+    action
+  )
+end
+
+---@type SmartSplitsMultiplexer
+local M = {}
+
+M.type = 'ghostty'
+
+function M.is_in_session()
+  -- Ghostty sets TERM_PROGRAM=ghostty in every terminal it spawns.
+  local term = vim.trim((vim.env.TERM_PROGRAM or ''):lower())
+  return term == 'ghostty'
+end
+
+function M.current_pane_id()
+  -- Return the UUID of the currently focused Ghostty terminal (split).
+  -- This is used by mux/init.lua to detect whether next_pane() actually moved focus.
+  local id = osascript_str(
+    'tell application "Ghostty"\n'
+      .. '  return id of (focused terminal of selected tab of front window) as string\n'
+      .. 'end tell'
+  )
+  if id == '' then
+    log.debug('ghostty: failed to get current pane id')
+    return nil
+  end
+  log.trace('ghostty: current_pane_id = %s', id)
+  return id
+end
+
+function M.current_pane_at_edge()
+  -- Ghostty does not expose split layout topology via AppleScript, so edge
+  -- position cannot be queried directly. Return false and let mux/init.lua's
+  -- pane-ID comparison fallback detect when a move had no effect.
+  return false
+end
+
+function M.current_pane_is_zoomed()
+  -- Ghostty supports toggle_split_zoom but does not expose zoom state via
+  -- AppleScript properties. Return false conservatively.
+  return false
+end
+
+function M.next_pane(direction)
+  if not M.is_in_session() then
+    return false
+  end
+
+  -- The recommended Ghostty integration uses `performable:` keybinds in the
+  -- Ghostty config (e.g. `keybind = performable:ctrl+h=goto_split:left`).
+  -- With that setup, Ghostty consumes the key and moves between Ghostty splits
+  -- itself when the action is performable; otherwise the key passes through to
+  -- Neovim for internal window navigation. next_pane() is therefore typically
+  -- not invoked during normal use, but is retained as an AppleScript fallback
+  -- for programmatic split control (e.g. smart-splits swap_buf).
+  --
+  -- perform action "goto_split:<direction>" returns true on success, or the
+  -- terminal's UUID string when no split exists in that direction.
+  local result = osascript_str(action_script('goto_split:' .. direction))
+  log.trace('ghostty: goto_split:%s result = %s', direction, result)
+  return result == 'true'
+end
+
+function M.resize_pane(direction, amount)
+  if not M.is_in_session() then
+    return false
+  end
+
+  local action = string.format('resize_split:%s,%s', direction, tostring(amount))
+  local result = osascript_str(action_script(action))
+  log.trace('ghostty: %s result = %s', action, result)
+  return result == 'true'
+end
+
+function M.split_pane(direction, _)
+  if not M.is_in_session() then
+    return false
+  end
+
+  local action = string.format('new_split:%s', direction)
+  local result = osascript_str(action_script(action))
+  log.trace('ghostty: %s result = %s', action, result)
+  return result == 'true'
+end
+
+-- on_init / on_exit: The recommended Ghostty integration relies on
+-- `performable:` keybinds in the Ghostty config rather than a runtime marker
+-- written by Neovim. Ghostty natively handles the "is this action possible
+-- right now?" check, making these no-ops. See next_pane() above for details.
+function M.on_init() end
+function M.on_exit() end
+
+function M.update_mux_layout_details()
+  -- No layout query API in Ghostty; edge detection falls back to pane-ID
+  -- comparison in mux/init.lua (move_multiplexer_inner).
+end
+
+return M

--- a/lua/smart-splits/mux/utils.lua
+++ b/lua/smart-splits/mux/utils.lua
@@ -26,6 +26,15 @@ function M.are_we_kitty()
   return vim.env.KITTY_LISTEN_ON ~= nil
 end
 
+function M.are_we_ghostty()
+  if M.are_we_gui() then
+    return false
+  end
+
+  local term = vim.trim((vim.env.TERM_PROGRAM or ''):lower())
+  return term == 'ghostty'
+end
+
 --- Check if we're in WSL
 ---@return boolean
 function M.is_WSL()

--- a/lua/smart-splits/types.lua
+++ b/lua/smart-splits/types.lua
@@ -17,7 +17,7 @@
 ---
 ---@alias SmartSplitsFloatWinBehavior 'previous'|'mux'
 
----@alias SmartSplitsMultiplexerType 'tmux'|'wezterm'|'kitty'|'zellij'
+---@alias SmartSplitsMultiplexerType 'tmux'|'wezterm'|'kitty'|'zellij'|'ghostty'
 
 ---@class SmartSplitsContext
 ---@field mux SmartSplitsMultiplexer|nil Multiplexer API, if one is currently in use
@@ -58,6 +58,8 @@ local M = {
     kitty = 'kitty',
     ---@type SmartSplitsMultiplexerType
     zellij = 'zellij',
+    ---@type SmartSplitsMultiplexerType
+    ghostty = 'ghostty',
   },
 }
 


### PR DESCRIPTION
## Summary

Adds a multiplexer backend for the [Ghostty](https://ghostty.org) terminal emulator.

## How it works

Ghostty navigation uses a two-part approach:

**Navigation** is handled entirely by Ghostty's [`performable:` keybind prefix](https://ghostty.org/docs/config/keybind#performable:). The user adds these to their Ghostty config:

```ini
keybind = performable:ctrl+h=goto_split:left
keybind = performable:ctrl+j=goto_split:down
keybind = performable:ctrl+k=goto_split:up
keybind = performable:ctrl+l=goto_split:right
```

`performable:` means Ghostty only consumes the key and moves focus when a split actually exists in that direction. If no split exists there (e.g. you're navigating between Neovim windows, or you're at the edge of the Ghostty layout), the key passes through to Neovim unchanged. This gives seamless bidirectional navigation with no escape-sequence handshake or runtime marker needed — it's the Ghostty-native equivalent of Kitty's `IS_NVIM` user var pattern.

**Resize and split creation** (`<A-h/j/k/l>` and `smart-splits.split_pane`) are implemented via AppleScript (`osascript`), using Ghostty's AppleScript API introduced in v1.3.0:

```applescript
tell application "Ghostty"
  set t to focused terminal of selected tab of front window
  perform action "resize_split:left,3" on t
end tell
```

`perform action` returns `true` on success or the terminal's UUID string when the action could not be performed, which is used as the success/failure signal.

## Changes

- **`lua/smart-splits/mux/ghostty.lua`** — new backend implementing the full `SmartSplitsMultiplexer` interface
- **`lua/smart-splits/mux/utils.lua`** — adds `are_we_ghostty()` (checks `TERM_PROGRAM=ghostty`)
- **`lua/smart-splits/config.lua`** — adds Ghostty to auto-detection; defaults `at_edge = 'stop'` when Ghostty is active (split layout topology is not queryable via AppleScript, same constraint as Kitty)
- **`lua/smart-splits/types.lua`** — adds `'ghostty'` to `SmartSplitsMultiplexerType`

## Limitations

- **macOS only** for resize/split — AppleScript is macOS-specific. Navigation via `performable:` keybinds works on all platforms Ghostty supports.
- **No edge detection** — `current_pane_at_edge()` returns `false`; edge handling falls back to pane-ID comparison in `mux/init.lua` (same as Kitty).
- **No zoom detection** — `current_pane_is_zoomed()` returns `false`; Ghostty's AppleScript API does not expose zoom state.