### PR TITLE
fix: kitty script does not copy the files 

### DIFF
--- a/kitty/install-kittens.bash
+++ b/kitty/install-kittens.bash
@@ -2,6 +2,6 @@
 
 PREFIX="${XDG_CONFIG_HOME:-$HOME/.config}"
 KITTY_CONFIG_PATH="$PREFIX/kitty"
-cp -f ./kitty/neighboring_window.py "$KITTY_CONFIG_PATH/"
-cp -f ./kitty/relative_resize.py "$KITTY_CONFIG_PATH/"
-cp -f ./kitty/split_window.py "$KITTY_CONFIG_PATH/"
+cp -f neighboring_window.py "$KITTY_CONFIG_PATH/"
+cp -f relative_resize.py "$KITTY_CONFIG_PATH/"
+cp -f split_window.py "$KITTY_CONFIG_PATH/"

--- a/kitty/install-kittens.bash
+++ b/kitty/install-kittens.bash
@@ -2,6 +2,8 @@
 
 PREFIX="${XDG_CONFIG_HOME:-$HOME/.config}"
 KITTY_CONFIG_PATH="$PREFIX/kitty"
-cp -f ./neighboring_window.py "$KITTY_CONFIG_PATH/"
-cp -f ./relative_resize.py "$KITTY_CONFIG_PATH/"
-cp -f ./split_window.py "$KITTY_CONFIG_PATH/"
+# this gives you the directory path that this script lives inside
+SCRIPT_DIR="$(dirname "$(realpath $0)")"
+cp -f "$SCRIPT_DIR/neighboring_window.py" "$KITTY_CONFIG_PATH/"
+cp -f "$SCRIPT_DIR/relative_resize.py" "$KITTY_CONFIG_PATH/"
+cp -f "$SCRIPT_DIR/split_window.py" "$KITTY_CONFIG_PATH/"

--- a/kitty/install-kittens.bash
+++ b/kitty/install-kittens.bash
@@ -2,6 +2,6 @@
 
 PREFIX="${XDG_CONFIG_HOME:-$HOME/.config}"
 KITTY_CONFIG_PATH="$PREFIX/kitty"
-cp -f neighboring_window.py "$KITTY_CONFIG_PATH/"
-cp -f relative_resize.py "$KITTY_CONFIG_PATH/"
-cp -f split_window.py "$KITTY_CONFIG_PATH/"
+cp -f ./neighboring_window.py "$KITTY_CONFIG_PATH/"
+cp -f ./relative_resize.py "$KITTY_CONFIG_PATH/"
+cp -f ./split_window.py "$KITTY_CONFIG_PATH/"


### PR DESCRIPTION
The script *install-kittens-bash* copy some python files to enable the integration between Neovim and Kitty Terminal, but the path of the python files was incorrect in the script.

Wrong path: 
cp -f ./kitty/neighboring_window.py "$KITTY_CONFIG_PATH/"
cp -f ./kitty/relative_resize.py "$KITTY_CONFIG_PATH/"
cp -f ./kitty/split_window.py "$KITTY_CONFIG_PATH/"

Correct path:
cp -f ./neighboring_window.py "$KITTY_CONFIG_PATH/"
cp -f ./relative_resize.py "$KITTY_CONFIG_PATH/"
cp -f ./split_window.py "$KITTY_CONFIG_PATH/"

Because the path was incorrect, the integration does not work after installing the plugin in Neovim using 
```lua
{ 'mrjones2014/smart-splits.nvim', build = './kitty/install-kittens.bash' }
```
