### PR TITLE
feat: add Herdr multiplexer integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ require('smart-splits').swap_buf_right({ move_cursor = true })
 ### Multiplexer Integrations
 
 `smart-splits.nvim` can also enable seamless navigation between Neovim splits and `tmux`, `zellij`, `wezterm`, `kitty`, or `herdr` panes.
-You will need to set up keymaps in your terminal multiplexer config to match the Neovim keymaps.
+You will need to set up keymaps in your `tmux`, `wezterm`, `kitty`, or `herdr` configs to match the Neovim keymaps.
 
 You can also set the desired multiplexer integration in lazy environments before the plugin is loaded by setting
 `vim.g.smart_splits_multiplexer_integration`. The values are the same as described in [Configuration](#configuration).
@@ -563,7 +563,7 @@ To make this work, you will need to forward the Kitty socket, what exposes your 
 According to Kitty's [documentation](https://sw.kovidgoyal.net/kitty/kittens/ssh/#opt-kitten-ssh.forward_remote_control):
 
 > **WARNING**: This allows any software on the remote host full access to the local computer, so only do it for trusted remote hosts.
-
+ 
 In addition to the above instructions, you will need to add the following to your local `~/.config/kitty/ssh.conf`:
 
 ```
@@ -600,17 +600,13 @@ require('smart-splits').setup({
 })
 ```
 
-Install the bundled Herdr plugin and operate the directly through the plugin:
-
-```sh
-herdr plugin install mrjones2014/smart-splits.nvim/herdr
-```
-
-If you are developing locally, link the working checkout instead:
+To enable tmux-style direct keybindings in both Neovim and non-Neovim panes, link the bundled Herdr plugin from your local checkout and route the keys through plugin actions:
 
 ```sh
 herdr plugin link /path/to/smart-splits.nvim/herdr
 ```
+
+Then add the following to your Herdr keybindings:
 
 ```toml
 [[keys.command]]
@@ -654,11 +650,11 @@ type = "plugin_action"
 command = "smart-splits.nvim.resize-right"
 ```
 
-The Herdr plugin invokes smart-splits commands directly in Neovim when the focused pane is a Neovim pane; otherwise it focuses or resizes the adjacent Herdr pane. Neovim panes are identified using a marker recorded on startup, which keeps dispatch responsive without coupling Herdr keybindings to Neovim keymaps.
+The dispatch script routes the keypress to Neovim when the focused pane is a Neovim pane (identified via a marker file written on startup), otherwise it focuses or resizes the adjacent Herdr pane.
 
 #### Configuring the Herdr resize amount
 
-By default the plugin resizes non-Neovim Herdr panes by 0.03. To customize this, create a `config.sh` file in the plugin config directory Herdr creates for you:
+By default the dispatch script resizes non-Neovim Herdr panes by `0.03`. To customize this, create a `config.sh` file in the plugin config directory Herdr creates for you:
 
 ```sh
 herdr plugin config-dir smart-splits.nvim
@@ -670,9 +666,7 @@ Create `config.sh` in that directory and set `SMART_SPLITS_HERDR_RESIZE_AMOUNT`:
 SMART_SPLITS_HERDR_RESIZE_AMOUNT=0.01
 ```
 
-The dispatch script sources this file before each resize, so changes take effect on the next key press — no restart needed.
-
-If you prefer, you can still export `SMART_SPLITS_HERDR_RESIZE_AMOUNT` as an environment variable; a config file value takes precedence over the default, and an exported variable overrides both.
+The dispatch script sources this file before each resize, so changes take effect on the next key press. You can also export `SMART_SPLITS_HERDR_RESIZE_AMOUNT` as an environment variable; an exported variable takes precedence over the config file.
 
 ### Multiplexer Lua API
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ multiplexer split panes. See [Multiplexer Integrations](#multiplexer-integration
     - [Wezterm](#wezterm)
     - [Kitty](#kitty)
       - [Credits](#credits)
+    - [Herdr](#herdr)
   - [Multiplexer Lua API](#multiplexer-lua-api)
 
 <!--toc:end-->
@@ -91,7 +92,7 @@ require('smart-splits').setup({
   -- a context object with the following fields:
   -- {
   --    mux = {
-  --      type:'tmux'|'wezterm'|'kitty'|'zellij'
+  --      type:'tmux'|'wezterm'|'kitty'|'zellij'|'herdr'
   --      current_pane_id():number,
   --      is_in_session(): boolean
   --      current_pane_is_zoomed():boolean,
@@ -149,6 +150,8 @@ require('smart-splits').setup({
   -- In Zellij, set this to true if you would like to move to the next *tab*
   -- when the current pane is at the edge of the zellij tab/window
   zellij_move_focus_or_tab = false,
+  -- Custom herdr CLI path if `herdr` is not on $PATH inside Neovim
+  herdr_cli_path = nil,
   -- default logging level, one of: 'trace'|'debug'|'info'|'warn'|'error'|'fatal'
   log_level = 'info',
 })
@@ -222,8 +225,8 @@ require('smart-splits').swap_buf_right({ move_cursor = true })
 
 ### Multiplexer Integrations
 
-`smart-splits.nvim` can also enable seamless navigation between Neovim splits and `tmux`, `zellij`, `wezterm`, or `kitty` panes.
-You will need to set up keymaps in your `tmux`, `wezterm`, or `kitty` configs to match the Neovim keymaps.
+`smart-splits.nvim` can also enable seamless navigation between Neovim splits and `tmux`, `zellij`, `wezterm`, `kitty`, or `herdr` panes.
+You will need to set up keymaps in your terminal multiplexer config to match the Neovim keymaps.
 
 You can also set the desired multiplexer integration in lazy environments before the plugin is loaded by setting
 `vim.g.smart_splits_multiplexer_integration`. The values are the same as described in [Configuration](#configuration).
@@ -560,7 +563,7 @@ To make this work, you will need to forward the Kitty socket, what exposes your 
 According to Kitty's [documentation](https://sw.kovidgoyal.net/kitty/kittens/ssh/#opt-kitten-ssh.forward_remote_control):
 
 > **WARNING**: This allows any software on the remote host full access to the local computer, so only do it for trusted remote hosts.
- 
+
 In addition to the above instructions, you will need to add the following to your local `~/.config/kitty/ssh.conf`:
 
 ```
@@ -587,6 +590,90 @@ Thanks @knubie for inspiration for the Kitty implementation from [vim-kitty-navi
 
 Thanks to @chancez for the relative resize [Python kitten](https://github.com/chancez/dotfiles/blob/badc69d3895a6a942285126b8c372a55d77533e1/kitty/.config/kitty/relative_resize.py).
 
+#### Herdr
+
+Herdr support uses the `herdr` CLI from inside Neovim. If `HERDR_SOCKET_PATH` is set, the integration is auto-detected; otherwise set it explicitly:
+
+```lua
+require('smart-splits').setup({
+  multiplexer_integration = 'herdr',
+})
+```
+
+Install the bundled Herdr plugin and operate the directly through the plugin:
+
+```sh
+herdr plugin install mrjones2014/smart-splits.nvim/herdr
+```
+
+If you are developing locally, link the working checkout instead:
+
+```sh
+herdr plugin link /path/to/smart-splits.nvim/herdr
+```
+
+```toml
+[[keys.command]]
+key = "ctrl+h"
+type = "plugin_action"
+command = "smart-splits.nvim.move-left"
+
+[[keys.command]]
+key = "ctrl+j"
+type = "plugin_action"
+command = "smart-splits.nvim.move-down"
+
+[[keys.command]]
+key = "ctrl+k"
+type = "plugin_action"
+command = "smart-splits.nvim.move-up"
+
+[[keys.command]]
+key = "ctrl+l"
+type = "plugin_action"
+command = "smart-splits.nvim.move-right"
+
+[[keys.command]]
+key = "alt+h"
+type = "plugin_action"
+command = "smart-splits.nvim.resize-left"
+
+[[keys.command]]
+key = "alt+j"
+type = "plugin_action"
+command = "smart-splits.nvim.resize-down"
+
+[[keys.command]]
+key = "alt+k"
+type = "plugin_action"
+command = "smart-splits.nvim.resize-up"
+
+[[keys.command]]
+key = "alt+l"
+type = "plugin_action"
+command = "smart-splits.nvim.resize-right"
+```
+
+The Herdr plugin invokes smart-splits commands directly in Neovim when the focused pane is a Neovim pane; otherwise it focuses or resizes the adjacent Herdr pane. Neovim panes are identified using a marker recorded on startup, which keeps dispatch responsive without coupling Herdr keybindings to Neovim keymaps.
+
+#### Configuring the Herdr resize amount
+
+By default the plugin resizes non-Neovim Herdr panes by 0.03. To customize this, create a `config.sh` file in the plugin config directory Herdr creates for you:
+
+```sh
+herdr plugin config-dir smart-splits.nvim
+```
+
+Create `config.sh` in that directory and set `SMART_SPLITS_HERDR_RESIZE_AMOUNT`:
+
+```sh
+SMART_SPLITS_HERDR_RESIZE_AMOUNT=0.01
+```
+
+The dispatch script sources this file before each resize, so changes take effect on the next key press — no restart needed.
+
+If you prefer, you can still export `SMART_SPLITS_HERDR_RESIZE_AMOUNT` as an environment variable; a config file value takes precedence over the default, and an exported variable overrides both.
+
 ### Multiplexer Lua API
 
 You can directly access the multiplexer API for scripting purposes as well.
@@ -610,7 +697,7 @@ local mux = require('smart-splits.mux').get()
 ---@field next_pane fun(direction:'left'|'right'|'up'|'down'):boolean
 ---@field resize_pane fun(direction:'left'|'right'|'up'|'down', amount:number):boolean
 ---@field split_pane fun(direction:'left'|'right'|'up'|'down',size:number|nil):boolean
----@field type 'tmux'|'wezterm'|'kitty'|'zellij'
+---@field type 'tmux'|'wezterm'|'kitty'|'zellij'|'herdr'
 ```
 
 ### Persistent Resize Mode

--- a/doc/smart-splits.nvim.txt
+++ b/doc/smart-splits.nvim.txt
@@ -100,7 +100,7 @@ Defaults are shown below:
       -- a context object with the following fields:
       -- {
       --    mux = {
-      --      type:'tmux'|'wezterm'|'kitty'|'zellij'
+      --      type:'tmux'|'wezterm'|'kitty'|'zellij'|'herdr'
       --      current_pane_id():number,
       --      is_in_session(): boolean
       --      current_pane_is_zoomed():boolean,
@@ -235,9 +235,8 @@ LUA API                                      *smart-splits.nvim-usage-lua-api*
 MULTIPLEXER INTEGRATIONS    *smart-splits.nvim-usage-multiplexer-integrations*
 
 `smart-splits.nvim` can also enable seamless navigation between Neovim splits
-and `tmux`, `zellij`, `wezterm`, or `kitty` panes. You will need to set up
-keymaps in your `tmux`, `wezterm`, or `kitty` configs to match the Neovim
-keymaps.
+and `tmux`, `zellij`, `wezterm`, `kitty`, or `herdr` panes. You will need to set
+up keymaps in your terminal multiplexer config to match the Neovim keymaps.
 
 You can also set the desired multiplexer integration in lazy environments
 before the plugin is loaded by setting
@@ -625,6 +624,7 @@ For troubleshooting, please refer to Kitty’s SSH remote control documentation
 <https://sw.kovidgoyal.net/kitty/kittens/ssh/>.
 
 
+
 CREDITS
 
 Thanks @knubie for inspiration for the Kitty implementation from
@@ -633,6 +633,90 @@ vim-kitty-navigator <https://github.com/knubie/vim-kitty-navigator>.
 Thanks to @chancez for the relative resize Python kitten
 <https://github.com/chancez/dotfiles/blob/badc69d3895a6a942285126b8c372a55d77533e1/kitty/.config/kitty/relative_resize.py>.
 
+
+HERDR ~
+
+Herdr support uses the `herdr` CLI from inside Neovim. If `HERDR_SOCKET_PATH`
+is set, the integration is auto-detected; otherwise set it explicitly:
+
+>lua
+    require('smart-splits').setup({
+      multiplexer_integration = 'herdr',
+    })
+<
+
+For Neovim-only smart navigation, keep Herdr pane navigation on prefix bindings
+so `Ctrl+h/j/k/l` reaches Neovim:
+
+>toml
+    [keys]
+    focus_pane_left = "prefix+h"
+    focus_pane_down = "prefix+j"
+    focus_pane_up = "prefix+k"
+    focus_pane_right = "prefix+l"
+<
+
+To get tmux-style direct bindings in both Neovim and non-Neovim panes, link the
+bundled Herdr plugin and route the direct keys through plugin actions:
+
+>sh
+    herdr plugin link /path/to/smart-splits.nvim/herdr
+<
+
+>toml
+    [keys]
+    focus_pane_left = "prefix+h"
+    focus_pane_down = "prefix+j"
+    focus_pane_up = "prefix+k"
+    focus_pane_right = "prefix+l"
+    
+    [[keys.command]]
+    key = "ctrl+h"
+    type = "plugin_action"
+    command = "smart-splits.nvim.move-left"
+    
+    [[keys.command]]
+    key = "ctrl+j"
+    type = "plugin_action"
+    command = "smart-splits.nvim.move-down"
+    
+    [[keys.command]]
+    key = "ctrl+k"
+    type = "plugin_action"
+    command = "smart-splits.nvim.move-up"
+    
+    [[keys.command]]
+    key = "ctrl+l"
+    type = "plugin_action"
+    command = "smart-splits.nvim.move-right"
+    
+    [[keys.command]]
+    key = "alt+h"
+    type = "plugin_action"
+    command = "smart-splits.nvim.resize-left"
+    
+    [[keys.command]]
+    key = "alt+j"
+    type = "plugin_action"
+    command = "smart-splits.nvim.resize-down"
+    
+    [[keys.command]]
+    key = "alt+k"
+    type = "plugin_action"
+    command = "smart-splits.nvim.resize-up"
+    
+    [[keys.command]]
+    key = "alt+l"
+    type = "plugin_action"
+    command = "smart-splits.nvim.resize-right"
+<
+
+The Herdr plugin invokes smart-splits commands directly in Neovim when the
+focused pane is a Neovim pane; otherwise it focuses or resizes the adjacent
+Herdr pane. Neovim panes are identified using a marker recorded on startup,
+which keeps dispatch responsive without coupling Herdr keybindings to Neovim
+keymaps. Set `SMART_SPLITS_HERDR_RESIZE_AMOUNT` in the Herdr environment to
+customize the non-Neovim resize step size.
 
 MULTIPLEXER LUA API              *smart-splits.nvim-usage-multiplexer-lua-api*
 
@@ -657,7 +741,7 @@ currently in use. The API offers the following methods:
     ---@field next_pane fun(direction:'left'|'right'|'up'|'down'):boolean
     ---@field resize_pane fun(direction:'left'|'right'|'up'|'down', amount:number):boolean
     ---@field split_pane fun(direction:'left'|'right'|'up'|'down',size:number|nil):boolean
-    ---@field type 'tmux'|'wezterm'|'kitty'|'zellij'
+    ---@field type 'tmux'|'wezterm'|'kitty'|'zellij'|'herdr'
 <
 
 

--- a/doc/smart-splits.nvim.txt
+++ b/doc/smart-splits.nvim.txt
@@ -235,8 +235,9 @@ LUA API                                      *smart-splits.nvim-usage-lua-api*
 MULTIPLEXER INTEGRATIONS    *smart-splits.nvim-usage-multiplexer-integrations*
 
 `smart-splits.nvim` can also enable seamless navigation between Neovim splits
-and `tmux`, `zellij`, `wezterm`, `kitty`, or `herdr` panes. You will need to set
-up keymaps in your terminal multiplexer config to match the Neovim keymaps.
+and `tmux`, `zellij`, `wezterm`, `kitty`, or `herdr` panes. You will need to
+set up keymaps in your `tmux`, `wezterm`, `kitty`, or `herdr` configs to match
+the Neovim keymaps.
 
 You can also set the desired multiplexer integration in lazy environments
 before the plugin is loaded by setting
@@ -624,7 +625,6 @@ For troubleshooting, please refer to Kitty’s SSH remote control documentation
 <https://sw.kovidgoyal.net/kitty/kittens/ssh/>.
 
 
-
 CREDITS
 
 Thanks @knubie for inspiration for the Kitty implementation from
@@ -645,78 +645,60 @@ is set, the integration is auto-detected; otherwise set it explicitly:
     })
 <
 
-For Neovim-only smart navigation, keep Herdr pane navigation on prefix bindings
-so `Ctrl+h/j/k/l` reaches Neovim:
-
->toml
-    [keys]
-    focus_pane_left = "prefix+h"
-    focus_pane_down = "prefix+j"
-    focus_pane_up = "prefix+k"
-    focus_pane_right = "prefix+l"
-<
-
-To get tmux-style direct bindings in both Neovim and non-Neovim panes, link the
-bundled Herdr plugin and route the direct keys through plugin actions:
+To enable tmux-style direct keybindings in both Neovim and non-Neovim panes,
+link the bundled Herdr plugin and route the keys through plugin actions:
 
 >sh
     herdr plugin link /path/to/smart-splits.nvim/herdr
 <
 
 >toml
-    [keys]
-    focus_pane_left = "prefix+h"
-    focus_pane_down = "prefix+j"
-    focus_pane_up = "prefix+k"
-    focus_pane_right = "prefix+l"
-    
     [[keys.command]]
     key = "ctrl+h"
     type = "plugin_action"
     command = "smart-splits.nvim.move-left"
-    
+
     [[keys.command]]
     key = "ctrl+j"
     type = "plugin_action"
     command = "smart-splits.nvim.move-down"
-    
+
     [[keys.command]]
     key = "ctrl+k"
     type = "plugin_action"
     command = "smart-splits.nvim.move-up"
-    
+
     [[keys.command]]
     key = "ctrl+l"
     type = "plugin_action"
     command = "smart-splits.nvim.move-right"
-    
+
     [[keys.command]]
     key = "alt+h"
     type = "plugin_action"
     command = "smart-splits.nvim.resize-left"
-    
+
     [[keys.command]]
     key = "alt+j"
     type = "plugin_action"
     command = "smart-splits.nvim.resize-down"
-    
+
     [[keys.command]]
     key = "alt+k"
     type = "plugin_action"
     command = "smart-splits.nvim.resize-up"
-    
+
     [[keys.command]]
     key = "alt+l"
     type = "plugin_action"
     command = "smart-splits.nvim.resize-right"
 <
 
-The Herdr plugin invokes smart-splits commands directly in Neovim when the
-focused pane is a Neovim pane; otherwise it focuses or resizes the adjacent
-Herdr pane. Neovim panes are identified using a marker recorded on startup,
-which keeps dispatch responsive without coupling Herdr keybindings to Neovim
-keymaps. Set `SMART_SPLITS_HERDR_RESIZE_AMOUNT` in the Herdr environment to
-customize the non-Neovim resize step size.
+The dispatch script routes the keypress to Neovim when the focused pane is a
+Neovim pane (identified via a marker file written on startup), otherwise it
+focuses or resizes the adjacent Herdr pane. Set
+`SMART_SPLITS_HERDR_RESIZE_AMOUNT` in the Herdr environment to customize the
+non-Neovim resize step size.
 
 MULTIPLEXER LUA API              *smart-splits.nvim-usage-multiplexer-lua-api*
 

--- a/herdr/dispatch.sh
+++ b/herdr/dispatch.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-}"
+direction="${2:-}"
+
+case "$mode:$direction" in
+move:left | move:down | move:up | move:right | resize:left | resize:down | resize:up | resize:right) ;;
+*)
+  echo "usage: dispatch.sh move|resize left|down|up|right" >&2
+  exit 2
+  ;;
+esac
+
+herdr_bin="${HERDR_BIN_PATH:-herdr}"
+pane_id="${HERDR_PANE_ID:-${HERDR_ACTIVE_PANE_ID:-}}"
+
+if [ -z "$pane_id" ]; then
+  context_json="${HERDR_PLUGIN_CONTEXT_JSON:-}"
+  if command -v python3 >/dev/null 2>&1 && [ -n "$context_json" ]; then
+    pane_id="$(
+      HERDR_PLUGIN_CONTEXT_JSON="$context_json" python3 - <<'PY'
+import json
+import os
+
+try:
+    print(json.loads(os.environ.get("HERDR_PLUGIN_CONTEXT_JSON", "{}"))\
+        .get("focused_pane_id", ""))
+except Exception:
+    pass
+PY
+    )"
+  fi
+fi
+
+if [ -z "$pane_id" ]; then
+  echo "smart-splits herdr plugin: focused pane id is unavailable" >&2
+  exit 1
+fi
+
+marker_dir() {
+  echo "${XDG_CACHE_HOME:-$HOME/.cache}/smart-splits.nvim/herdr-panes"
+}
+
+marker_path() {
+  local pane="$1"
+  printf '%s/%s\n' "$(marker_dir)" "$pane"
+}
+
+is_nvim_pane() {
+  local pane="$1"
+
+  # Match tmux's hot-path design: use the state recorded by Neovim on init,
+  # and avoid per-keypress CLI/process inspection.
+  [ -f "$(marker_path "$pane")" ]
+}
+
+marker_value() {
+  local pane="$1"
+  local key="$2"
+  local path
+  path="$(marker_path "$pane")"
+
+  while IFS= read -r line; do
+    case "$line" in
+    "$key"=*)
+      printf '%s\n' "${line#*=}"
+      return 0
+      ;;
+    esac
+  done <"$path"
+  return 1
+}
+
+nvim_command_for() {
+  case "$mode:$direction" in
+  resize:left) echo "SmartResizeLeft" ;;
+  resize:down) echo "SmartResizeDown" ;;
+  resize:up) echo "SmartResizeUp" ;;
+  resize:right) echo "SmartResizeRight" ;;
+  move:left) echo "SmartCursorMoveLeft" ;;
+  move:down) echo "SmartCursorMoveDown" ;;
+  move:up) echo "SmartCursorMoveUp" ;;
+  move:right) echo "SmartCursorMoveRight" ;;
+  esac
+}
+
+invoke_nvim_command() {
+  local pane="$1"
+  local command="$2"
+  local server
+  local nvim_bin
+
+  server="$(marker_value "$pane" server || true)"
+  nvim_bin="$(marker_value "$pane" nvim || true)"
+
+  if [ -z "$server" ]; then
+    echo "smart-splits herdr plugin: Neovim pane marker has no RPC server; restart Neovim to refresh the marker" >&2
+    return 1
+  fi
+
+  if [ -z "$nvim_bin" ]; then
+    nvim_bin="${NVIM_BIN:-nvim}"
+  fi
+
+  "$nvim_bin" --server "$server" --remote-expr "execute('$command')" >/dev/null
+}
+
+if is_nvim_pane "$pane_id"; then
+  invoke_nvim_command "$pane_id" "$(nvim_command_for)"
+  exit 0
+fi
+
+# Load user config from the per-plugin config directory Herdr creates.
+# Users set SMART_SPLITS_HERDR_RESIZE_AMOUNT there instead of exporting it on
+# the command line. See herdr/config.example for a template.
+config_file="${HERDR_PLUGIN_CONFIG_DIR:-$HOME/.config/herdr/plugins/config/smart-splits.nvim}/config.sh"
+if [ -f "$config_file" ]; then
+  # shellcheck source=/dev/null
+  . "$config_file"
+fi
+
+if [ "$mode" = "resize" ]; then
+  amount="${SMART_SPLITS_HERDR_RESIZE_AMOUNT:-0.03}"
+  "$herdr_bin" pane resize --pane "$pane_id" --direction "$direction" --amount "$amount" >/dev/null
+else
+  "$herdr_bin" pane focus --pane "$pane_id" --direction "$direction" >/dev/null
+fi

--- a/herdr/dispatch.sh
+++ b/herdr/dispatch.sh
@@ -5,32 +5,23 @@ mode="${1:-}"
 direction="${2:-}"
 
 case "$mode:$direction" in
-move:left | move:down | move:up | move:right | resize:left | resize:down | resize:up | resize:right) ;;
-*)
-  echo "usage: dispatch.sh move|resize left|down|up|right" >&2
-  exit 2
-  ;;
+  move:left | move:down | move:up | move:right) ;;
+  resize:left | resize:down | resize:up | resize:right) ;;
+  *)
+    echo "usage: dispatch.sh move|resize left|down|up|right" >&2
+    exit 2
+    ;;
 esac
 
 herdr_bin="${HERDR_BIN_PATH:-herdr}"
 pane_id="${HERDR_PANE_ID:-${HERDR_ACTIVE_PANE_ID:-}}"
 
-if [ -z "$pane_id" ]; then
-  context_json="${HERDR_PLUGIN_CONTEXT_JSON:-}"
-  if command -v python3 >/dev/null 2>&1 && [ -n "$context_json" ]; then
-    pane_id="$(
-      HERDR_PLUGIN_CONTEXT_JSON="$context_json" python3 - <<'PY'
-import json
-import os
-
-try:
-    print(json.loads(os.environ.get("HERDR_PLUGIN_CONTEXT_JSON", "{}"))\
-        .get("focused_pane_id", ""))
-except Exception:
-    pass
-PY
-    )"
-  fi
+# Fallback: extract focused_pane_id from the plugin context JSON
+# using only sed, avoiding any external language dependency.
+if [ -z "$pane_id" ] && [ -n "${HERDR_PLUGIN_CONTEXT_JSON:-}" ]; then
+  pane_id="$(printf '%s' "$HERDR_PLUGIN_CONTEXT_JSON" \
+    | sed -n 's/.*"focused_pane_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    | head -1)"
 fi
 
 if [ -z "$pane_id" ]; then
@@ -39,20 +30,11 @@ if [ -z "$pane_id" ]; then
 fi
 
 marker_dir() {
-  echo "${XDG_CACHE_HOME:-$HOME/.cache}/smart-splits.nvim/herdr-panes"
+  printf '%s/smart-splits.nvim/herdr-panes\n' "${XDG_CACHE_HOME:-$HOME/.cache}"
 }
 
 marker_path() {
-  local pane="$1"
-  printf '%s/%s\n' "$(marker_dir)" "$pane"
-}
-
-is_nvim_pane() {
-  local pane="$1"
-
-  # Match tmux's hot-path design: use the state recorded by Neovim on init,
-  # and avoid per-keypress CLI/process inspection.
-  [ -f "$(marker_path "$pane")" ]
+  printf '%s/%s\n' "$(marker_dir)" "$1"
 }
 
 marker_value() {
@@ -60,64 +42,75 @@ marker_value() {
   local key="$2"
   local path
   path="$(marker_path "$pane")"
-
   while IFS= read -r line; do
     case "$line" in
-    "$key"=*)
-      printf '%s\n' "${line#*=}"
-      return 0
-      ;;
+      "$key"=*)
+        printf '%s\n' "${line#*=}"
+        return 0
+        ;;
     esac
   done <"$path"
   return 1
 }
 
+is_nvim_pane() {
+  local pane="$1"
+  local path
+  path="$(marker_path "$pane")"
+  [ -f "$path" ] || return 1
+
+  # Check that the marker's PID is still alive, so stale markers
+  # from crashed Neovim sessions are ignored.
+  local pid
+  pid="$(marker_value "$pane" pid 2>/dev/null || true)"
+  if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+    return 1
+  fi
+  return 0
+}
+
 nvim_command_for() {
   case "$mode:$direction" in
-  resize:left) echo "SmartResizeLeft" ;;
-  resize:down) echo "SmartResizeDown" ;;
-  resize:up) echo "SmartResizeUp" ;;
-  resize:right) echo "SmartResizeRight" ;;
-  move:left) echo "SmartCursorMoveLeft" ;;
-  move:down) echo "SmartCursorMoveDown" ;;
-  move:up) echo "SmartCursorMoveUp" ;;
-  move:right) echo "SmartCursorMoveRight" ;;
+    resize:left) echo 'SmartResizeLeft' ;;
+    resize:down) echo 'SmartResizeDown' ;;
+    resize:up) echo 'SmartResizeUp' ;;
+    resize:right) echo 'SmartResizeRight' ;;
+    move:left) echo 'SmartCursorMoveLeft' ;;
+    move:down) echo 'SmartCursorMoveDown' ;;
+    move:up) echo 'SmartCursorMoveUp' ;;
+    move:right) echo 'SmartCursorMoveRight' ;;
   esac
 }
 
 invoke_nvim_command() {
   local pane="$1"
   local command="$2"
-  local server
-  local nvim_bin
+  local server nvim_bin
 
-  server="$(marker_value "$pane" server || true)"
-  nvim_bin="$(marker_value "$pane" nvim || true)"
-
+  server="$(marker_value "$pane" server 2>/dev/null || true)"
   if [ -z "$server" ]; then
-    echo "smart-splits herdr plugin: Neovim pane marker has no RPC server; restart Neovim to refresh the marker" >&2
+    echo "smart-splits herdr plugin: Neovim pane marker has no RPC server" >&2
     return 1
   fi
 
+  nvim_bin="$(marker_value "$pane" nvim 2>/dev/null || true)"
   if [ -z "$nvim_bin" ]; then
     nvim_bin="${NVIM_BIN:-nvim}"
   fi
 
-  "$nvim_bin" --server "$server" --remote-expr "execute('$command')" >/dev/null
+  "$nvim_bin" --server "$server" --remote-send "<Cmd>${command}<CR>"
 }
 
-if is_nvim_pane "$pane_id"; then
-  invoke_nvim_command "$pane_id" "$(nvim_command_for)"
-  exit 0
-fi
-
-# Load user config from the per-plugin config directory Herdr creates.
-# Users set SMART_SPLITS_HERDR_RESIZE_AMOUNT there instead of exporting it on
-# the command line. See herdr/config.example for a template.
+# Load user config from the per-plugin config directory.
 config_file="${HERDR_PLUGIN_CONFIG_DIR:-$HOME/.config/herdr/plugins/config/smart-splits.nvim}/config.sh"
 if [ -f "$config_file" ]; then
   # shellcheck source=/dev/null
   . "$config_file"
+fi
+
+if is_nvim_pane "$pane_id"; then
+  invoke_nvim_command "$pane_id" "$(nvim_command_for)"
+  exit 0
 fi
 
 if [ "$mode" = "resize" ]; then

--- a/herdr/herdr-plugin.toml
+++ b/herdr/herdr-plugin.toml
@@ -1,0 +1,54 @@
+id = "smart-splits.nvim"
+name = "smart-splits.nvim"
+version = "0.1.0"
+min_herdr_version = "0.7.0"
+description = "smart navigation between Neovim windows and Herdr panes."
+platforms = ["linux", "macos"]
+
+[[actions]]
+id = "move-left"
+title = "Smart move left"
+contexts = ["pane"]
+command = ["bash", "dispatch.sh", "move", "left"]
+
+[[actions]]
+id = "move-down"
+title = "Smart move down"
+contexts = ["pane"]
+command = ["bash", "dispatch.sh", "move", "down"]
+
+[[actions]]
+id = "move-up"
+title = "Smart move up"
+contexts = ["pane"]
+command = ["bash", "dispatch.sh", "move", "up"]
+
+[[actions]]
+id = "move-right"
+title = "Smart move right"
+contexts = ["pane"]
+command = ["bash", "dispatch.sh", "move", "right"]
+
+[[actions]]
+id = "resize-left"
+title = "Smart resize left"
+contexts = ["pane"]
+command = ["bash", "dispatch.sh", "resize", "left"]
+
+[[actions]]
+id = "resize-down"
+title = "Smart resize down"
+contexts = ["pane"]
+command = ["bash", "dispatch.sh", "resize", "down"]
+
+[[actions]]
+id = "resize-up"
+title = "Smart resize up"
+contexts = ["pane"]
+command = ["bash", "dispatch.sh", "resize", "up"]
+
+[[actions]]
+id = "resize-right"
+title = "Smart resize right"
+contexts = ["pane"]
+command = ["bash", "dispatch.sh", "resize", "right"]

--- a/lua/smart-splits/config.lua
+++ b/lua/smart-splits/config.lua
@@ -25,6 +25,7 @@ local mux_utils = require('smart-splits.mux.utils')
 ---@field wezterm_cli_path string|nil
 ---@field kitty_password string|nil
 ---@field zellij_move_focus_or_tab boolean
+---@field herdr_cli_path string|nil
 ---@field setup fun(cfg:table)
 ---@field set_default_multiplexer fun():string|nil
 ---@field log_level 'trace'|'debug'|'info'|'warn'|'error'|'fatal'
@@ -53,6 +54,7 @@ local config = { ---@diagnostic disable-line:missing-fields
   disable_multiplexer_nav_when_zoomed = true,
   kitty_password = nil,
   zellij_move_focus_or_tab = false,
+  herdr_cli_path = nil,
   log_level = 'info',
 }
 
@@ -96,7 +98,9 @@ function M.set_default_multiplexer()
   end
 
   local term = vim.trim((vim.env.TERM_PROGRAM or ''):lower())
-  if term == 'tmux' then
+  if mux_utils.are_we_herdr() then
+    config.multiplexer_integration = Multiplexer.herdr
+  elseif term == 'tmux' then
     config.multiplexer_integration = Multiplexer.tmux
   elseif vim.env.ZELLIJ ~= nil then
     config.multiplexer_integration = 'zellij'

--- a/lua/smart-splits/mux/herdr.lua
+++ b/lua/smart-splits/mux/herdr.lua
@@ -38,18 +38,16 @@ local function nvim_server_address()
   if servername ~= nil and servername ~= '' then
     return servername
   end
-
-  local ok, address = pcall(vim.fn.serverstart)
-  if ok and type(address) == 'string' and address ~= '' then
-    return address
-  end
   return nil
 end
 
 local function write_marker(pane_id)
   pcall(vim.fn.mkdir, marker_dir(), 'p')
 
-  local lines = { 'version=1' }
+  local lines = {
+    'version=2',
+    'pid=' .. tostring(vim.fn.getpid()),
+  }
   local server = nvim_server_address()
   if server then
     table.insert(lines, 'server=' .. server)
@@ -65,42 +63,30 @@ local function remove_marker(pane_id)
   pcall(vim.fn.delete, marker_path(pane_id))
 end
 
----@param output string|table|nil
----@param key string|nil
----@return table|nil
 local function herdr_result(output, key)
-  if type(output) ~= 'string' or #output == 0 then
+  if not output or #output == 0 then
     return nil
   end
-
   local ok, decoded = pcall(vim.json.decode, output)
-  if not ok or type(decoded) ~= 'table' or decoded.error ~= nil or type(decoded.result) ~= 'table' then
+  if not ok or type(decoded) ~= 'table' then
     return nil
   end
-
+  local result = decoded.result or decoded
   if key then
-    return decoded.result[key]
+    return result[key]
   end
-  return decoded.result
+  return result
 end
 
----Execute a herdr CLI command
----@param args string[]
----@param as_list boolean|nil return output as list instead of string
----@return string|table|nil, number|nil
-local function herdr_exec(args, as_list)
+local function herdr_exec(args)
   local cli_path = config.herdr_cli_path or 'herdr'
   local cmd = vim.list_extend({ cli_path }, args)
   local ok, output, code = pcall(require('smart-splits.utils').system, cmd)
   if not ok then
-    log.debug('herdr command failed: %s %s', table.concat(cmd, ' '), output)
+    log.debug('herdr command failed: %s', table.concat(cmd, ' '))
     return nil, 1
   end
-  if as_list then
-    return vim.split(output or '', '\n', { trimempty = true }), code
-  else
-    return output, code
-  end
+  return output, code
 end
 
 ---@type SmartSplitsMultiplexer
@@ -117,8 +103,8 @@ function M.current_pane_id()
     return nil
   end
 
-  local list_output, list_code = herdr_exec({ 'pane', 'list' })
-  local panes = list_code == 0 and herdr_result(list_output, 'panes') or nil
+  local output, code = herdr_exec({ 'pane', 'list' })
+  local panes = code == 0 and herdr_result(output, 'panes') or nil
   if type(panes) == 'table' then
     for _, pane in ipairs(panes) do
       if pane.focused == true and pane.pane_id ~= nil then
@@ -133,17 +119,14 @@ function M.current_pane_id()
     return tostring(pane_id)
   end
 
-  local output, code = herdr_exec({ 'pane', 'current' })
-  local pane = code == 0 and herdr_result(output, 'pane') or nil
+  local current_output, current_code = herdr_exec({ 'pane', 'current' })
+  local pane = current_code == 0 and herdr_result(current_output, 'pane') or nil
   if type(pane) == 'table' and pane.pane_id ~= nil then
     return tostring(pane.pane_id)
   end
   return nil
 end
 
----Check if the current pane is at the edge in the given direction.
----@param direction SmartSplitsDirection
----@return boolean
 function M.current_pane_at_edge(direction)
   if not M.is_in_session() then
     return false
@@ -153,8 +136,8 @@ function M.current_pane_at_edge(direction)
     return false
   end
 
-  local edges_output, edges_code = herdr_exec({ 'pane', 'edges', '--current' })
-  local edges = edges_code == 0 and herdr_result(edges_output, 'edges') or nil
+  local output, code = herdr_exec({ 'pane', 'edges', '--current' })
+  local edges = code == 0 and herdr_result(output, 'edges') or nil
   if type(edges) == 'table' and edges[dir] ~= nil then
     return edges[dir] == true
   end
@@ -184,15 +167,8 @@ function M.next_pane(direction)
   if not dir then
     return false
   end
-  local output, code = herdr_exec({ 'pane', 'focus', '--direction', dir, '--current' })
-  if code ~= 0 then
-    return false
-  end
-  local focus = herdr_result(output, 'focus')
-  if type(focus) == 'table' then
-    return focus.changed == true
-  end
-  return true
+  local _, code = herdr_exec({ 'pane', 'focus', '--direction', dir, '--current' })
+  return code == 0
 end
 
 function M.resize_pane(direction, amount)
@@ -203,15 +179,8 @@ function M.resize_pane(direction, amount)
   if not dir then
     return false
   end
-  local output, code = herdr_exec({ 'pane', 'resize', '--direction', dir, '--amount', tostring(amount), '--current' })
-  if code ~= 0 then
-    return false
-  end
-  local resize = herdr_result(output, 'resize')
-  if type(resize) == 'table' then
-    return resize.changed == true
-  end
-  return true
+  local _, code = herdr_exec({ 'pane', 'resize', '--direction', dir, '--amount', tostring(amount), '--current' })
+  return code == 0
 end
 
 function M.split_pane(direction, size)
@@ -246,55 +215,46 @@ end
 
 function M.on_init()
   local pane_id = M.current_pane_id()
-  if pane_id then
-    registered_pane_id = tostring(pane_id)
-    write_marker(registered_pane_id)
-    vim.system(
-      {
-        config.herdr_cli_path or 'herdr',
-        'pane',
-        'report-agent',
-        registered_pane_id,
-        '--source',
-        'smart-splits',
-        '--agent',
-        'neovim',
-        '--state',
-        'idle',
-      },
-      { detach = true }
-    )
+  if not pane_id then
+    return
   end
-
+  registered_pane_id = tostring(pane_id)
+  write_marker(registered_pane_id)
+  vim.fn.jobstart({
+    config.herdr_cli_path or 'herdr',
+    'pane',
+    'report-agent',
+    registered_pane_id,
+    '--source',
+    'smart-splits',
+    '--agent',
+    'neovim',
+    '--state',
+    'idle',
+  }, { detach = true })
 end
 
 function M.on_exit()
   local pane_id = registered_pane_id or M.current_pane_id()
-  if pane_id then
-    remove_marker(pane_id)
-    vim.system(
-      {
-        config.herdr_cli_path or 'herdr',
-        'pane',
-        'release-agent',
-        tostring(pane_id),
-        '--source',
-        'smart-splits',
-        '--agent',
-        'neovim',
-      },
-      { detach = true }
-    )
+  if not pane_id then
+    return
   end
+  remove_marker(pane_id)
+  vim.fn.jobstart({
+    config.herdr_cli_path or 'herdr',
+    'pane',
+    'release-agent',
+    tostring(pane_id),
+    '--source',
+    'smart-splits',
+    '--agent',
+    'neovim',
+  }, { detach = true })
   registered_pane_id = nil
 end
 
 function M.update_mux_layout_details()
-  if not M.is_in_session() then
-    return
-  end
-  -- Fetch layout details for potential future caching/optimization.
-  herdr_exec({ 'pane', 'list' })
+  -- Not implemented yet - check Kitty mux for reference
 end
 
 return M

--- a/lua/smart-splits/mux/herdr.lua
+++ b/lua/smart-splits/mux/herdr.lua
@@ -1,0 +1,300 @@
+local types = require('smart-splits.types')
+local Direction = types.Direction
+local lazy = require('smart-splits.lazy')
+local config = lazy.require_on_index('smart-splits.config') --[[@as SmartSplitsConfig]]
+local log = lazy.require_on_exported_call('smart-splits.log')
+
+local dir_keys_herdr = {
+  [Direction.left] = 'left',
+  [Direction.right] = 'right',
+  [Direction.up] = 'up',
+  [Direction.down] = 'down',
+}
+
+-- herdr split only supports 'right' and 'down'; for left/up we split then swap
+local split_dir_herdr = {
+  [Direction.left] = 'right',
+  [Direction.right] = 'right',
+  [Direction.up] = 'down',
+  [Direction.down] = 'down',
+}
+
+local registered_pane_id
+
+local function marker_dir()
+  local cache_home = vim.env.XDG_CACHE_HOME
+  if cache_home == nil or cache_home == '' then
+    cache_home = (vim.env.HOME or vim.fn.expand('~')) .. '/.cache'
+  end
+  return cache_home .. '/smart-splits.nvim/herdr-panes'
+end
+
+local function marker_path(pane_id)
+  return marker_dir() .. '/' .. tostring(pane_id)
+end
+
+local function nvim_server_address()
+  local servername = vim.v.servername
+  if servername ~= nil and servername ~= '' then
+    return servername
+  end
+
+  local ok, address = pcall(vim.fn.serverstart)
+  if ok and type(address) == 'string' and address ~= '' then
+    return address
+  end
+  return nil
+end
+
+local function write_marker(pane_id)
+  pcall(vim.fn.mkdir, marker_dir(), 'p')
+
+  local lines = { 'version=1' }
+  local server = nvim_server_address()
+  if server then
+    table.insert(lines, 'server=' .. server)
+  end
+  if vim.v.progpath and vim.v.progpath ~= '' then
+    table.insert(lines, 'nvim=' .. vim.v.progpath)
+  end
+
+  pcall(vim.fn.writefile, lines, marker_path(pane_id))
+end
+
+local function remove_marker(pane_id)
+  pcall(vim.fn.delete, marker_path(pane_id))
+end
+
+---@param output string|table|nil
+---@param key string|nil
+---@return table|nil
+local function herdr_result(output, key)
+  if type(output) ~= 'string' or #output == 0 then
+    return nil
+  end
+
+  local ok, decoded = pcall(vim.json.decode, output)
+  if not ok or type(decoded) ~= 'table' or decoded.error ~= nil or type(decoded.result) ~= 'table' then
+    return nil
+  end
+
+  if key then
+    return decoded.result[key]
+  end
+  return decoded.result
+end
+
+---Execute a herdr CLI command
+---@param args string[]
+---@param as_list boolean|nil return output as list instead of string
+---@return string|table|nil, number|nil
+local function herdr_exec(args, as_list)
+  local cli_path = config.herdr_cli_path or 'herdr'
+  local cmd = vim.list_extend({ cli_path }, args)
+  local ok, output, code = pcall(require('smart-splits.utils').system, cmd)
+  if not ok then
+    log.debug('herdr command failed: %s %s', table.concat(cmd, ' '), output)
+    return nil, 1
+  end
+  if as_list then
+    return vim.split(output or '', '\n', { trimempty = true }), code
+  else
+    return output, code
+  end
+end
+
+---@type SmartSplitsMultiplexer
+local M = {} ---@diagnostic disable-line: missing-fields
+
+M.type = 'herdr'
+
+function M.is_in_session()
+  return vim.env.HERDR_SOCKET_PATH ~= nil and vim.env.HERDR_SOCKET_PATH ~= ''
+end
+
+function M.current_pane_id()
+  if not M.is_in_session() then
+    return nil
+  end
+
+  local list_output, list_code = herdr_exec({ 'pane', 'list' })
+  local panes = list_code == 0 and herdr_result(list_output, 'panes') or nil
+  if type(panes) == 'table' then
+    for _, pane in ipairs(panes) do
+      if pane.focused == true and pane.pane_id ~= nil then
+        return tostring(pane.pane_id)
+      end
+    end
+  end
+
+  -- Fallback to the pane this Neovim process was launched in.
+  local pane_id = vim.env.HERDR_PANE_ID
+  if pane_id and #pane_id > 0 then
+    return tostring(pane_id)
+  end
+
+  local output, code = herdr_exec({ 'pane', 'current' })
+  local pane = code == 0 and herdr_result(output, 'pane') or nil
+  if type(pane) == 'table' and pane.pane_id ~= nil then
+    return tostring(pane.pane_id)
+  end
+  return nil
+end
+
+---Check if the current pane is at the edge in the given direction.
+---@param direction SmartSplitsDirection
+---@return boolean
+function M.current_pane_at_edge(direction)
+  if not M.is_in_session() then
+    return false
+  end
+  local dir = dir_keys_herdr[direction]
+  if not dir then
+    return false
+  end
+
+  local edges_output, edges_code = herdr_exec({ 'pane', 'edges', '--current' })
+  local edges = edges_code == 0 and herdr_result(edges_output, 'edges') or nil
+  if type(edges) == 'table' and edges[dir] ~= nil then
+    return edges[dir] == true
+  end
+
+  local neighbor_output, neighbor_code = herdr_exec({ 'pane', 'neighbor', '--direction', dir, '--current' })
+  local neighbor = neighbor_code == 0 and herdr_result(neighbor_output, 'neighbor') or nil
+  return type(neighbor) == 'table' and neighbor.neighbor_pane_id == nil
+end
+
+function M.current_pane_is_zoomed()
+  if not M.is_in_session() then
+    return false
+  end
+  local output, code = herdr_exec({ 'pane', 'layout', '--current' })
+  if code ~= 0 or not output then
+    return false
+  end
+  local layout = herdr_result(output, 'layout')
+  return type(layout) == 'table' and layout.zoomed == true
+end
+
+function M.next_pane(direction)
+  if not M.is_in_session() then
+    return false
+  end
+  local dir = dir_keys_herdr[direction]
+  if not dir then
+    return false
+  end
+  local output, code = herdr_exec({ 'pane', 'focus', '--direction', dir, '--current' })
+  if code ~= 0 then
+    return false
+  end
+  local focus = herdr_result(output, 'focus')
+  if type(focus) == 'table' then
+    return focus.changed == true
+  end
+  return true
+end
+
+function M.resize_pane(direction, amount)
+  if not M.is_in_session() then
+    return false
+  end
+  local dir = dir_keys_herdr[direction]
+  if not dir then
+    return false
+  end
+  local output, code = herdr_exec({ 'pane', 'resize', '--direction', dir, '--amount', tostring(amount), '--current' })
+  if code ~= 0 then
+    return false
+  end
+  local resize = herdr_result(output, 'resize')
+  if type(resize) == 'table' then
+    return resize.changed == true
+  end
+  return true
+end
+
+function M.split_pane(direction, size)
+  if not M.is_in_session() then
+    return false
+  end
+  local split_dir = split_dir_herdr[direction]
+  if not split_dir then
+    return false
+  end
+
+  local args = { 'pane', 'split', '--direction', split_dir, '--current', '--focus' }
+  local need_swap
+  if direction == Direction.left then
+    need_swap = 'left'
+  elseif direction == Direction.up then
+    need_swap = 'up'
+  end
+  if size then
+    table.insert(args, '--ratio')
+    table.insert(args, tostring(size))
+  end
+  local _, split_code = herdr_exec(args)
+  if need_swap ~= nil then
+    local _, swap_code = herdr_exec({ 'pane', 'swap', '--direction', need_swap, '--current' })
+    M.update_mux_layout_details()
+    return split_code == 0 and swap_code == 0
+  end
+  M.update_mux_layout_details()
+  return split_code == 0
+end
+
+function M.on_init()
+  local pane_id = M.current_pane_id()
+  if pane_id then
+    registered_pane_id = tostring(pane_id)
+    write_marker(registered_pane_id)
+    vim.system(
+      {
+        config.herdr_cli_path or 'herdr',
+        'pane',
+        'report-agent',
+        registered_pane_id,
+        '--source',
+        'smart-splits',
+        '--agent',
+        'neovim',
+        '--state',
+        'idle',
+      },
+      { detach = true }
+    )
+  end
+
+end
+
+function M.on_exit()
+  local pane_id = registered_pane_id or M.current_pane_id()
+  if pane_id then
+    remove_marker(pane_id)
+    vim.system(
+      {
+        config.herdr_cli_path or 'herdr',
+        'pane',
+        'release-agent',
+        tostring(pane_id),
+        '--source',
+        'smart-splits',
+        '--agent',
+        'neovim',
+      },
+      { detach = true }
+    )
+  end
+  registered_pane_id = nil
+end
+
+function M.update_mux_layout_details()
+  if not M.is_in_session() then
+    return
+  end
+  -- Fetch layout details for potential future caching/optimization.
+  herdr_exec({ 'pane', 'list' })
+end
+
+return M

--- a/lua/smart-splits/mux/utils.lua
+++ b/lua/smart-splits/mux/utils.lua
@@ -26,6 +26,16 @@ function M.are_we_kitty()
   return vim.env.KITTY_LISTEN_ON ~= nil
 end
 
+---Check if we're in a Herdr session
+---@return boolean
+function M.are_we_herdr()
+  if M.are_we_gui() then
+    return false
+  end
+
+  return vim.env.HERDR_SOCKET_PATH ~= nil and vim.env.HERDR_SOCKET_PATH ~= ''
+end
+
 --- Check if we're in WSL
 ---@return boolean
 function M.are_we_WSL()

--- a/lua/smart-splits/types.lua
+++ b/lua/smart-splits/types.lua
@@ -17,7 +17,7 @@
 ---
 ---@alias SmartSplitsFloatWinBehavior 'previous'|'mux'
 
----@alias SmartSplitsMultiplexerType 'tmux'|'wezterm'|'kitty'|'zellij'
+---@alias SmartSplitsMultiplexerType 'tmux'|'wezterm'|'kitty'|'zellij'|'herdr'
 
 ---@class SmartSplitsContext
 ---@field mux SmartSplitsMultiplexer|nil Multiplexer API, if one is currently in use
@@ -58,6 +58,8 @@ local M = {
     kitty = 'kitty',
     ---@type SmartSplitsMultiplexerType
     zellij = 'zellij',
+    ---@type SmartSplitsMultiplexerType
+    herdr = 'herdr',
   },
 }
 


### PR DESCRIPTION
## Summary

Adds [Herdr](https://herdr.dev) as a new multiplexer backend for smart-splits.nvim, alongside the existing tmux, zellij, wezterm, and kitty integrations.

Closes #460

## Changes

- **`lua/smart-splits/mux/herdr.lua`** — New mux backend implementing the full `SmartSplitsMultiplexer` interface: `is_in_session`, `current_pane_id`, `next_pane`, `resize_pane`, `split_pane`, `current_pane_at_edge`, `current_pane_is_zoomed`, `update_mux_layout_details`, plus `on_init`/`on_exit` lifecycle hooks that register/deregister the Neovim pane via a marker file so the dispatch script can identify Neovim panes without coupling keybindings.
- **`lua/smart-splits/mux/utils.lua`** — New `are_we_herdr()` detection via `HERDR_SOCKET_PATH`.
- **`lua/smart-splits/types.lua`** — Register `herdr` in the `Multiplexer` enum and `SmartSplitsMultiplexerType` alias.
- **`lua/smart-splits/config.lua`** — Auto-detect Herdr in `set_default_multiplexer()`; add `herdr_cli_path` config option for non-`$PATH` installs.
- **`herdr/`** — Bundled Herdr plugin with:
  - `herdr-plugin.toml` — plugin manifest exposing 8 actions (move/resize × left/down/up/right)
  - `dispatch.sh` — dispatch script that routes focus/resize to Neovim (via RPC) or the adjacent Herdr pane, with per-plugin config support for `SMART_SPLITS_HERDR_RESIZE_AMOUNT`
- **`README.md` / `doc/smart-splits.nvim.txt`** — Full documentation for the Herdr integration, keybindings, and resize configuration.

## How it works

The Herdr plugin invokes smart-splits commands directly in Neovim when the focused pane is a Neovim pane; otherwise it focuses or resizes the adjacent Herdr pane. Neovim panes are identified using a marker file recorded on startup, which keeps dispatch responsive without coupling Herdr keybindings to Neovim keymaps.