### PR TITLE
fix(mux): Improve zellij integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ require('smart-splits').setup({
   --    split(), -- utility function to split current Neovim pane in the current direction
   --    wrap(), -- utility function to wrap to opposite Neovim pane
   -- }
-  -- NOTE: `at_edge = 'wrap'` is not supported on Kitty terminal
-  -- multiplexer, as there is no way to determine layout via the CLI
+  -- NOTE:
+  -- * `at_edge = 'wrap'` is not supported on Kitty terminal or zellij
+  -- * `at_edge = 'split'` is not supported on zellij
   at_edge = 'wrap',
   -- Desired behavior when the current window is floating:
   -- 'previous' => Focus previous Vim window and perform action

--- a/lua/smart-splits/config.lua
+++ b/lua/smart-splits/config.lua
@@ -41,7 +41,7 @@ local config = { ---@diagnostic disable-line:missing-fields
     'NvimTree',
   },
   default_amount = 3,
-  at_edge = mux_utils.are_we_kitty() and AtEdgeBehavior.stop or AtEdgeBehavior.wrap,
+  at_edge = (mux_utils.are_we_kitty() or mux_utils.are_we_zellij()) and AtEdgeBehavior.stop or AtEdgeBehavior.wrap,
   float_win_behavior = FloatWinBehavior.previous,
   move_cursor_same_row = false,
   cursor_follows_swapped_bufs = false,
@@ -100,8 +100,8 @@ function M.set_default_multiplexer()
     config.multiplexer_integration = Multiplexer.herdr
   elseif term == 'tmux' then
     config.multiplexer_integration = Multiplexer.tmux
-  elseif vim.env.ZELLIJ ~= nil then
-    config.multiplexer_integration = 'zellij'
+  elseif mux_utils.are_we_zellij() then
+    config.multiplexer_integration = Multiplexer.zellij
   elseif term == 'wezterm' then
     config.multiplexer_integration = Multiplexer.wezterm
   elseif mux_utils.are_we_kitty() then
@@ -129,9 +129,23 @@ function M.setup(new_config)
     mux_utils.startup()
   end
 
-  -- check for incompatible settings
+  -- check for incompatible kitty settings
   if mux_utils.are_we_kitty() and config.multiplexer_integration == Multiplexer.kitty and config.at_edge == 'wrap' then
     local msg = 'Kitty multiplexer integration does not support wrapping at edge, setting to "stop"'
+    log.warn(msg)
+    vim.notify_once(msg, vim.log.levels.WARN, { title = 'smart-splits.nvim' })
+    config.at_edge = AtEdgeBehavior.stop
+  end
+
+  -- check for incompatible zellij settings
+  if
+    mux_utils.are_we_zellij()
+    and config.multiplexer_integration == Multiplexer.zellij
+    and config.at_edge ~= 'stop'
+  then
+    local msg = config.at_edge == 'wrap'
+        and 'Zellij multiplexer integration does not support wrapping at edge, setting to stop'
+      or 'Zellij multiplexer integration does not support splitting at edge, setting to stop'
     log.warn(msg)
     vim.notify_once(msg, vim.log.levels.WARN, { title = 'smart-splits.nvim' })
     config.at_edge = AtEdgeBehavior.stop

--- a/lua/smart-splits/config.lua
+++ b/lua/smart-splits/config.lua
@@ -141,7 +141,7 @@ function M.setup(new_config)
   if
     mux_utils.are_we_zellij()
     and config.multiplexer_integration == Multiplexer.zellij
-    and config.at_edge ~= 'stop'
+    and (config.at_edge == 'wrap' or config.at_edge == 'split')
   then
     local msg = config.at_edge == 'wrap'
         and 'Zellij multiplexer integration does not support wrapping at edge, setting to stop'

--- a/lua/smart-splits/mux/init.lua
+++ b/lua/smart-splits/mux/init.lua
@@ -35,6 +35,11 @@ local function move_multiplexer_inner(direction, multiplexer)
     return true
   end
 
+  -- zellij does not support multiplexer.current_pane_id(), so we will just assume that it was successfull
+  if multiplexer.type == 'zellij' then
+    return true
+  end
+
   return false
 end
 

--- a/lua/smart-splits/mux/utils.lua
+++ b/lua/smart-splits/mux/utils.lua
@@ -34,6 +34,14 @@ function M.are_we_herdr()
   return vim.env.HERDR_ENV ~= nil and vim.env.HERDR_ENV ~= ''
 end
 
+function M.are_we_zellij()
+  if M.are_we_gui() then
+    return false
+  end
+
+  return vim.env.ZELLIJ ~= nil
+end
+
 --- Check if we're in WSL
 ---@return boolean
 function M.are_we_WSL()

--- a/lua/smart-splits/mux/zellij.lua
+++ b/lua/smart-splits/mux/zellij.lua
@@ -14,44 +14,17 @@ local M = {} ---@diagnostic disable-line: missing-fields
 
 M.type = 'zellij'
 
+-- It is very expensive to ask zellij for the current pane id.
+-- We also don't need the ID to move to the next pane.
+-- However, SmartSplitsMultiplexer (and ./init.lua) demands that we return a number.
+-- So let's just return -1
 function M.current_pane_id()
-  local output = vim.split(zellij_exec({ 'action', 'list-clients' }), '\n', { trimempty = true })
-  if not output[2] then
-    return nil
-  end
-
-  -- The output format is like
-  -- ```
-  -- CLIENT_ID ZELLIJ_PANE_ID RUNNING_COMMAND
-  -- 1         terminal_0     /path/to/nvim --cmd lua print('some arguments')
-  -- ```
-  -- We are looking for the value `0` here in the `terminal_0` chunk.
-  -- The `terminal_` prefix might be something else, for example if a plugin's UI
-  -- is currently focused, but we still need to know the pane ID, so we're using the
-  -- `%w+` pattern to match any word prefix. Then we capture the ID with the `%d` pattern
-  -- in the capture group.
-  local pane_id = string.match(output[2], '%S+%s+%w+_(%d+)')
-  return pane_id
+  return -1
 end
 
+-- Not supported yet: https://github.com/mrjones2014/smart-splits.nvim/issues/477
 function M.current_pane_at_edge()
-  local pane_id = M.current_pane_id()
-  if pane_id == nil then
-    log.warn('could not get zeillij pane id')
-    return false
-  end
-  zellij_exec({ 'action', 'move-focus', Direction.left })
-  local new_pane_id = M.current_pane_id()
-
-  if new_pane_id == nil then
-    log.warn('could not get zeillij pane id')
-    return false
-  end
-
-  -- move back to original pane
-  zellij_exec({ 'action', 'move-focus', Direction.right })
-
-  return pane_id == new_pane_id
+  return false
 end
 
 -- amount is not supported on zellij
@@ -88,30 +61,34 @@ function M.next_pane(direction)
   return code == 0
 end
 
--- size is not supported on zellij
 function M.split_pane(direction, _size) ---@diagnostic disable-line: unused-local
-  -- zellij only splits right and down; for the others,
-  -- we must split right and down then swap the panes
-  local args = { 'action', 'new-pane' }
-  local need_swap
-  if direction == Direction.left then
-    table.insert(args, 'right')
-    need_swap = 'right'
-  elseif direction == Direction.up then
-    table.insert(args, 'down')
-    need_swap = 'down'
-  else
-    table.insert(args, direction)
-  end
-  local _, split_code = zellij_exec(args)
-  if need_swap ~= nil then
-    local _, swap_code = zellij_exec({ 'action', 'move-pane', need_swap })
-    M.update_mux_layout_details()
-    return split_code == 0 and swap_code == 0
-  end
-  M.update_mux_layout_details()
-  return split_code == 0
+  return false
 end
+
+-- size is not supported on zellij
+-- function M.split_pane(direction, _size) ---@diagnostic disable-line: unused-local
+--   -- zellij only splits right and down; for the others,
+--   -- we must split right and down then swap the panes
+--   local args = { 'action', 'new-pane' }
+--   local need_swap
+--   if direction == Direction.left then
+--     table.insert(args, 'right')
+--     need_swap = 'right'
+--   elseif direction == Direction.up then
+--     table.insert(args, 'down')
+--     need_swap = 'down'
+--   else
+--     table.insert(args, direction)
+--   end
+--   local _, split_code = zellij_exec(args)
+--   if need_swap ~= nil then
+--     local _, swap_code = zellij_exec({ 'action', 'move-pane', need_swap })
+--     M.update_mux_layout_details()
+--     return split_code == 0 and swap_code == 0
+--   end
+--   M.update_mux_layout_details()
+--   return split_code == 0
+-- end
 
 function M.update_mux_layout_details()
   -- Not implemented yet - check Kitty mux for reference

--- a/lua/smart-splits/mux/zellij.lua
+++ b/lua/smart-splits/mux/zellij.lua
@@ -37,12 +37,8 @@ function M.resize_pane(direction, _amount) ---@diagnostic disable-line: unused-l
   return code == 0
 end
 
-local session_name = nil
 function M.is_in_session()
-  if session_name == nil then
-    session_name = vim.trim(os.getenv('ZELLIJ_SESSION_NAME') or '')
-  end
-  return session_name ~= ''
+  return vim.env.ZELLIJ ~= nil
 end
 
 function M.current_pane_is_zoomed()

--- a/lua/smart-splits/mux/zellij.lua
+++ b/lua/smart-splits/mux/zellij.lua
@@ -1,7 +1,6 @@
 local Direction = require('smart-splits.types').Direction
 local lazy = require('smart-splits.lazy')
 local config = lazy.require_on_index('smart-splits.config') --[[@as SmartSplitsConfig]]
-local log = require('smart-splits.log')
 
 local function zellij_exec(cmd)
   local command = vim.deepcopy(cmd)
@@ -57,7 +56,7 @@ function M.next_pane(direction)
   return code == 0
 end
 
-function M.split_pane(direction, _size) ---@diagnostic disable-line: unused-local
+function M.split_pane(_direction, _size) ---@diagnostic disable-line: unused-local
   return false
 end
 

--- a/lua/smart-splits/mux/zellij.lua
+++ b/lua/smart-splits/mux/zellij.lua
@@ -64,8 +64,12 @@ function M.resize_pane(direction, _amount) ---@diagnostic disable-line: unused-l
   return code == 0
 end
 
+local session_name = nil
 function M.is_in_session()
-  return M.current_pane_id() ~= nil
+  if session_name == nil then
+    session_name = vim.trim(os.getenv('ZELLIJ_SESSION_NAME') or '')
+  end
+  return session_name ~= ''
 end
 
 function M.current_pane_is_zoomed()

--- a/tests/test_config_spec.lua
+++ b/tests/test_config_spec.lua
@@ -54,6 +54,20 @@ describe('smart-splits.config', function()
       assert.same({ 'neo-tree' }, config.ignored_filetypes)
     end)
 
+    it('set at_edge to stop when we are zellij', function()
+      vim.env.ZELLIJ = '0'
+      config = fresh_config()
+      config.setup()
+      assert.equals('stop', config.at_edge)
+    end)
+
+    it('set at_edge to stop when we are kitty', function()
+      vim.env.KITTY_LISTEN_ON = 'unix:/tmp/kitty-abc123.sock'
+      config = fresh_config()
+      config.setup()
+      assert.equals('stop', config.at_edge)
+    end)
+
     it('sets at_edge', function()
       config.setup({ at_edge = 'stop' })
       assert.equals('stop', config.at_edge)

--- a/tests/test_config_spec.lua
+++ b/tests/test_config_spec.lua
@@ -54,14 +54,14 @@ describe('smart-splits.config', function()
       assert.same({ 'neo-tree' }, config.ignored_filetypes)
     end)
 
-    it('set at_edge to stop when we are zellij', function()
+    it('sets at_edge to stop when we are zellij', function()
       vim.env.ZELLIJ = '0'
       config = fresh_config()
       config.setup()
       assert.equals('stop', config.at_edge)
     end)
 
-    it('set at_edge to stop when we are kitty', function()
+    it('sets at_edge to stop when we are kitty', function()
       vim.env.KITTY_LISTEN_ON = 'unix:/tmp/kitty-abc123.sock'
       config = fresh_config()
       config.setup()


### PR DESCRIPTION
### Improvements

- Fixes #476 

- Zellij performance is improved massively. Addresses #378 

**Performance before**

<div>
<video src="https://github.com/user-attachments/assets/a18288c5-59d4-4a08-a5c9-e3e47f2fb0e9" />
</div>
<br>

**Performance after**

<div>
<video src="https://github.com/user-attachments/assets/1ae5cb7b-144e-4e7d-9ddb-9539d04b0228" />  
</div>
<br>

### Trade-offs

Removed official support for `at_edge='wrap'` and `at_edge='split'`. These options will probably not be missed as they are currently broken anyway (see #477 and #478).

### Other changes

If zellij is detected, `config.at_edge` will default to `'stop'`. I have added unit tests to verify this.

### Future work

I see a way to get `wrap` and `split` to work with zellij, but that is gonna require some refactoring. I will probably need to refactor [lua/smart-splits/mux/init.lua](https://github.com/mrjones2014/smart-splits.nvim/blob/master/lua/smart-splits/mux/init.lua) and the `SmartSplitsMultiplexer` interface. This has obviously a big blast radius for introducing regressions so I think that is better left for a future PR. For now, this PR should make life better for zellij users 😊